### PR TITLE
Finish orders drawing

### DIFF
--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -52,6 +52,9 @@ const WDMapController: React.FC = function (): React.ReactElement {
   const [scaleMin, scaleMax] = getInitialScaleForDevice(device);
 
   // FIXME: it's not ideal for us to be fetching the whole world from store here
+  // This is hard to untangle though because the representation of the data in the
+  // store is relatively bad. You have to depend on a lot of stuff in order to
+  // draw useful things right now.
   const viewedPhaseState = useAppSelector(gameViewedPhase);
   const overview = useAppSelector(gameOverview);
   const status = useAppSelector(gameStatus);
@@ -126,7 +129,7 @@ const WDMapController: React.FC = function (): React.ReactElement {
           }
         }
         const orderHistorical: IOrderDataHistorical = {
-          countryID: status.countryID.toString(),
+          countryID: status.countryID,
           dislodged: "No",
           fromTerrID,
           phase: overview.phase,
@@ -164,6 +167,7 @@ const WDMapController: React.FC = function (): React.ReactElement {
       unitsHistorical,
       overview.members,
       prevPhaseOrders,
+      phaseHistorical.orders,
     );
     return {
       phase: phaseHistorical.phase as string,

--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -17,12 +17,8 @@ import {
   gameUnits,
   gameViewedPhase,
 } from "../../state/game/game-api-slice";
-import getUnits from "../../utils/map/getUnits";
-import {
-  IOrderData,
-  IOrderDataHistorical,
-  IUnit,
-} from "../../models/Interfaces";
+import { getUnitsHistorical } from "../../utils/map/getUnits";
+import { IOrderData, IOrderDataHistorical } from "../../models/Interfaces";
 
 const Scales: Scale = {
   DESKTOP: [0.45, 3],
@@ -159,19 +155,15 @@ const WDMapController: React.FC = function (): React.ReactElement {
 
     const phaseHistorical = status.phases[viewedPhaseState.viewedPhaseIdx];
     const unitsHistorical = phaseHistorical.units;
-    const unitsConverted: { [key: string]: IUnit } = {};
-    unitsHistorical.forEach((unitHistorical, index) => {
-      unitsConverted[index] = {
-        id: index.toString(),
-        countryID: unitHistorical.countryID.toString(),
-        type: unitHistorical.unitType,
-        terrID: unitHistorical.terrID.toString(),
-      };
-    });
-    const unitsLive = getUnits(
+    const prevPhaseOrders =
+      viewedPhaseState.viewedPhaseIdx > 0
+        ? status.phases[viewedPhaseState.viewedPhaseIdx - 1].orders
+        : [];
+    const unitsLive = getUnitsHistorical(
       data.data.territories,
-      unitsConverted,
+      unitsHistorical,
       overview.members,
+      prevPhaseOrders,
     );
     return {
       phase: phaseHistorical.phase as string,

--- a/beta-src/src/components/map/WDMap.tsx
+++ b/beta-src/src/components/map/WDMap.tsx
@@ -38,6 +38,7 @@ const WDMap: React.ForwardRefExoticComponent<
           <WDArrowContainer
             phase={phase}
             orders={orders}
+            units={units}
             maps={maps}
             territories={territories}
           />

--- a/beta-src/src/components/map/components/WDArrowContainer.tsx
+++ b/beta-src/src/components/map/components/WDArrowContainer.tsx
@@ -22,36 +22,37 @@ function accumulateMoveOrderArrows(
   orders: IOrderDataHistorical[],
   territories: APITerritories,
 ): void {
-  console.log("drawMoveOrders");
+  // console.log("drawMoveOrders");
   orders
     .filter((order) => order.type === "Move")
     .forEach((order) => {
-      if (order.toTerrID) {
-        console.log({
-          order,
-          territories,
-          terrID: order.terrID,
-          lookup: territories[order.terrID],
-        });
-        const fromTerr = TerritoryMap[territories[order.terrID].name].territory;
-        const toTerr = TerritoryMap[territories[order.toTerrID].name].territory;
+      if (!order.toTerrID) {
+        return;
+      }
+      // console.log({
+      //   order,
+      //   territories,
+      //   terrID: order.terrID,
+      //   lookup: territories[order.terrID],
+      // });
+      const fromTerr = TerritoryMap[territories[order.terrID].name].territory;
+      const toTerr = TerritoryMap[territories[order.toTerrID].name].territory;
 
-        arrows.push(
-          drawArrowFunctional(
-            ArrowType.MOVE,
-            order.success === "Yes" ? ArrowColor.MOVE : ArrowColor.MOVE_FAILED,
-            "unit",
-            fromTerr,
-            "territory",
-            toTerr,
-          ),
-        );
-        // console.log("ARROW");
-        // console.log(arrows[0]);
+      arrows.push(
+        drawArrowFunctional(
+          ArrowType.MOVE,
+          order.success === "Yes" ? ArrowColor.MOVE : ArrowColor.MOVE_FAILED,
+          "unit",
+          fromTerr,
+          "territory",
+          toTerr,
+        ),
+      );
+      // console.log("ARROW");
+      // console.log(arrows[0]);
 
-        if (order.viaConvoy === "Yes") {
-          // TODO need to distinguish via vs nonvia orders??
-        }
+      if (order.viaConvoy === "Yes") {
+        // TODO need to distinguish via vs nonvia orders??
       }
     });
 }
@@ -218,6 +219,33 @@ function accumulateConvoyOrderArrows(
     });
 }
 
+function accumulateRetreatArrows(
+  arrows: (React.ReactElement | null)[],
+  orders: IOrderDataHistorical[],
+  territories: APITerritories,
+): void {
+  orders
+    .filter((order) => order.type === "Retreat")
+    .forEach((order) => {
+      if (!order.toTerrID) {
+        return;
+      }
+      const fromTerr = TerritoryMap[territories[order.terrID].name].territory;
+      const toTerr = TerritoryMap[territories[order.toTerrID].name].territory;
+
+      arrows.push(
+        drawArrowFunctional(
+          ArrowType.MOVE,
+          ArrowColor.RETREAT,
+          "unit",
+          fromTerr,
+          "territory",
+          toTerr,
+        ),
+      );
+    });
+}
+
 /*
 export interface IOrderDataHistorical {
   countryID: string;
@@ -257,6 +285,7 @@ const WDArrowContainer: React.FC<WDArrowProps> = function ({
   accumulateSupportHoldOrderArrows(arrows, orders, territories);
   accumulateSupportMoveOrderArrows(arrows, orders, ordersByTerrID, territories);
   accumulateConvoyOrderArrows(arrows, orders, ordersByTerrID, territories);
+  accumulateRetreatArrows(arrows, orders, territories);
   return <g id="arrows">{arrows}</g>;
 };
 

--- a/beta-src/src/components/map/components/WDArrowContainer.tsx
+++ b/beta-src/src/components/map/components/WDArrowContainer.tsx
@@ -12,6 +12,7 @@ import GameStateMaps from "../../../state/interfaces/GameStateMaps";
 import ArrowType from "../../../enums/ArrowType";
 import ArrowColor from "../../../enums/ArrowColor";
 import drawArrowFunctional, {
+  getTargetXYWH,
   getArrowX1Y1X2Y2,
 } from "../../../utils/map/drawArrowFunctional";
 import TerritoryMap from "../../../data/map/variants/classic/TerritoryMap";
@@ -273,6 +274,31 @@ function accumulateDislodgerArrows(
     });
 }
 
+// This isn't exactly an arrow, but...
+function accumulateBuildCircles(
+  arrows: (React.ReactElement | null)[],
+  units: Unit[],
+  territories: APITerritories,
+): void {
+  units
+    .filter((unit) => unit.isBuild)
+    .forEach((unit) => {
+      const terr = TerritoryMap[territories[unit.unit.terrID].name].territory;
+      const [x, y, w, h] = getTargetXYWH("unit", terr);
+
+      arrows.push(
+        <circle
+          key={`build-circle-${terr}`}
+          cx={x + w / 2}
+          cy={y + h / 2}
+          r={10 + (w + h) / 4}
+          fill="none"
+          stroke="rgb(0,150,0)"
+          strokeWidth={6}
+        />,
+      );
+    });
+}
 /*
 export interface IOrderDataHistorical {
   countryID: string;
@@ -316,6 +342,7 @@ const WDArrowContainer: React.FC<WDArrowProps> = function ({
   accumulateConvoyOrderArrows(arrows, orders, ordersByTerrID, territories);
   accumulateRetreatArrows(arrows, orders, territories);
   accumulateDislodgerArrows(arrows, units, territories);
+  accumulateBuildCircles(arrows, units, territories);
   return <g id="arrows">{arrows}</g>;
 };
 

--- a/beta-src/src/components/map/components/WDArrowContainer.tsx
+++ b/beta-src/src/components/map/components/WDArrowContainer.tsx
@@ -16,6 +16,7 @@ import drawArrowFunctional, {
 } from "../../../utils/map/drawArrowFunctional";
 import TerritoryMap from "../../../data/map/variants/classic/TerritoryMap";
 import { APITerritories } from "../../../state/interfaces/GameDataResponse";
+import { Unit } from "../../../utils/map/getUnits";
 
 function accumulateMoveOrderArrows(
   arrows: (React.ReactElement | null)[],
@@ -246,6 +247,32 @@ function accumulateRetreatArrows(
     });
 }
 
+function accumulateDislodgerArrows(
+  arrows: (React.ReactElement | null)[],
+  units: Unit[],
+  territories: APITerritories,
+): void {
+  units
+    .filter((unit) => unit.isDislodging)
+    .forEach((unit) => {
+      if (unit.movedFromTerrID === null) return;
+      const fromTerr =
+        TerritoryMap[territories[unit.movedFromTerrID].name].territory;
+      const toTerr = TerritoryMap[territories[unit.unit.terrID].name].territory;
+
+      arrows.push(
+        drawArrowFunctional(
+          ArrowType.MOVE,
+          ArrowColor.MOVE,
+          "territory",
+          fromTerr,
+          "dislodger",
+          toTerr,
+        ),
+      );
+    });
+}
+
 /*
 export interface IOrderDataHistorical {
   countryID: string;
@@ -265,6 +292,7 @@ export interface IOrderDataHistorical {
 interface WDArrowProps {
   phase: string;
   orders: IOrderDataHistorical[];
+  units: Unit[];
   maps: GameStateMaps;
   territories: APITerritories;
 }
@@ -272,6 +300,7 @@ interface WDArrowProps {
 const WDArrowContainer: React.FC<WDArrowProps> = function ({
   phase,
   orders,
+  units,
   maps,
   territories,
 }): React.ReactElement {
@@ -286,6 +315,7 @@ const WDArrowContainer: React.FC<WDArrowProps> = function ({
   accumulateSupportMoveOrderArrows(arrows, orders, ordersByTerrID, territories);
   accumulateConvoyOrderArrows(arrows, orders, ordersByTerrID, territories);
   accumulateRetreatArrows(arrows, orders, territories);
+  accumulateDislodgerArrows(arrows, units, territories);
   return <g id="arrows">{arrows}</g>;
 };
 

--- a/beta-src/src/components/map/components/WDTerritory.tsx
+++ b/beta-src/src/components/map/components/WDTerritory.tsx
@@ -66,9 +66,6 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
 
   const unitState = useAppSelector(gameUnitState); // FIXME: too global
   const unitFCs: { [key: string]: any } = {};
-  if (territory === Territory.BERLIN) {
-    console.log({ territory, units, territoryMeta });
-  }
   units
     .filter(
       (unit) =>
@@ -78,7 +75,7 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
     .forEach((unit) => {
       unitFCs[unit.mappedTerritory.unitSlotName] = (
         <WDUnit
-          id={`${territory}-unit`} // n.b. the id here is ref'd by drawOrders, do not change!
+          id={`${territory}-unit`}
           country={unit.country}
           meta={unit}
           type={unit.unit.type as UnitType}

--- a/beta-src/src/components/map/components/WDTerritory.tsx
+++ b/beta-src/src/components/map/components/WDTerritory.tsx
@@ -64,7 +64,6 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
     territoryFill = theme.palette[userCountry].main;
   }
 
-  const unitState = useAppSelector(gameUnitState); // FIXME: too global
   const unitFCs: { [key: string]: any } = {};
   const unitFCsDislodging: { [key: string]: any } = {};
   units
@@ -74,13 +73,18 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
         territoryMeta?.territory,
     )
     .forEach((unit) => {
+      let unitState: UIState = UIState.NONE;
+      if (unit.isBuild) {
+        unitState = UIState.BUILD;
+      }
+
       const wdUnit = (
         <WDUnit
           id={`${territory}-unit`}
           country={unit.country}
           meta={unit}
           type={unit.unit.type as UnitType}
-          iconState={unitState[unit.unit.id]} // FIXME make declarative
+          iconState={unitState}
         />
       );
       if (unit.isDislodging) {
@@ -88,37 +92,6 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
       } else {
         unitFCs[unit.mappedTerritory.unitSlotName] = wdUnit;
       }
-    });
-
-  const ordersMeta = useAppSelector(gameOrdersMeta);
-  Object.values(ordersMeta)
-    .filter(
-      ({ update }) =>
-        update &&
-        update.type.split(" ")[0] === "Build" && // updates can be something supporting you or moving to this territory???
-        update.toTerrID === territoryMeta?.id,
-    )
-    .forEach(({ update }) => {
-      territoryFillOpacity = 0.9;
-      // FIXME: needs to support coasts
-      unitFCs.main = (
-        <WDUnit
-          id={`${territory}-unit`}
-          country={userCountry}
-          meta={{
-            country: userCountry,
-            mappedTerritory: TerritoryMap[territory],
-            unit: {
-              id: `${territory}-unit`,
-              countryID: "NA",
-              type: update?.type.split(" ")[1] as unknown as string, // Build Army --> Army
-              terrID: territoryMeta?.id || "null",
-            },
-          }}
-          type={update?.type.split(" ")[1] as UnitType}
-          iconState={UIState.BUILD}
-        />
-      );
     });
 
   const clickAction = function (evt, clickObject: ClickObjectType) {

--- a/beta-src/src/models/Interfaces.ts
+++ b/beta-src/src/models/Interfaces.ts
@@ -37,6 +37,7 @@ export interface ICenter {
   terrID: string;
 }
 
+// What webdip api gives for LIVE units (in gameData response)
 export interface IUnit {
   id: string;
   countryID: string;
@@ -44,6 +45,7 @@ export interface IUnit {
   terrID: string;
 }
 
+// What webdip api gives for HISTORICAL units (in gameStatus response)
 export interface IUnitHistorical {
   unitType: string;
   retreating: string;

--- a/beta-src/src/models/Interfaces.ts
+++ b/beta-src/src/models/Interfaces.ts
@@ -55,6 +55,13 @@ export interface IUnitHistorical {
 
 export interface ITerrStatus {
   id: string;
+  // occupiedFromTerrID is used to mark where a unit came from when moving
+  // in to occupy another, and is used to determine what the legal retreat
+  // locations are for dislodged units. HOWEVER you cannot rely on this always
+  // to be non-null. It is null in case of a dislodgement-by-convoy due to
+  // needing to adjudicate certain convoy dislogement cornercases correctly.
+  // So this can NOT be relied on as an indicator of when a unit occupies
+  // another territory, it can ONLY be used for adjudicating retreat locations.
   occupiedFromTerrID: string | null;
   ownerCountryID: string | null;
   standoff: boolean;

--- a/beta-src/src/models/Interfaces.ts
+++ b/beta-src/src/models/Interfaces.ts
@@ -108,7 +108,7 @@ export interface IOrderData {
 }
 
 export interface IOrderDataHistorical {
-  countryID: string;
+  countryID: number;
   dislodged: string;
   fromTerrID: number;
   phase: string;

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -30,6 +30,7 @@ import fetchGameDataFulfilled from "../../utils/state/gameApiSlice/extraReducers
 import updateUserActivity from "../../utils/state/gameApiSlice/reducers/updateUserActivity";
 import TerritoriesMeta from "../interfaces/TerritoriesState";
 import fetchGameOverviewFulfilled from "../../utils/state/gameApiSlice/extraReducers/fetchGameOverview/fulfilled";
+import fetchGameStatusFulfilled from "../../utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled";
 import saveOrdersFulfilled from "../../utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled";
 import { IUnit } from "../../models/Interfaces";
 import { Unit } from "../../utils/map/getUnits";
@@ -244,19 +245,7 @@ const gameApiSlice = createSlice({
       .addCase(fetchGameStatus.pending, (state) => {
         state.apiStatus = "loading";
       })
-      .addCase(fetchGameStatus.fulfilled, (state, action) => {
-        state.apiStatus = "succeeded";
-        // If the user is scrolled to the current phase, make the viewed
-        // phase track the current phase
-        if (
-          state.viewedPhaseState.viewedPhaseIdx >=
-          state.status.phases.length - 1
-        ) {
-          state.viewedPhaseState.viewedPhaseIdx =
-            action.payload.phases.length - 1;
-        }
-        state.status = action.payload;
-      })
+      .addCase(fetchGameStatus.fulfilled, fetchGameStatusFulfilled)
       .addCase(fetchGameStatus.rejected, (state, action) => {
         state.apiStatus = "failed";
         state.error = action.error.message;

--- a/beta-src/src/utils/map/arrowDispatchReceiveCoordinates.ts
+++ b/beta-src/src/utils/map/arrowDispatchReceiveCoordinates.ts
@@ -1,11 +1,8 @@
 export default function arrowDispatchReceiveCoordinates(
-  positionChangeBuffer: number, // distance before changing receiver/dispatch position
   unitH: number, // dispatch unit height
   unitW: number, // dispatch unit width
   rh: number, // receiver height
   rw: number, // receiver width
-  xDiff: number, // horizontal diff between receiver and dispatch
-  yDiff: number, // vertical diff between receiver and dispatch
   X1: number, // line x1
   X2: number, // line x2
   Y1: number, // line y1
@@ -20,70 +17,60 @@ export default function arrowDispatchReceiveCoordinates(
   let x2 = X2;
   let y1 = Y1;
   let y2 = Y2;
-  if (Math.abs(xDiff) < positionChangeBuffer && yDiff < 0) {
-    // dispatch: top center
-    x1 += unitW / 2;
-    // receiver: bottom center
-    if (rw && rh) {
-      x2 += rw / 2;
-      y2 += rh;
-    }
-  } else if (Math.abs(xDiff) < positionChangeBuffer && yDiff > 0) {
-    // dispatch: bottom center
-    y1 += unitH;
-    x1 += unitW / 2;
-    // receiver: top center
-    if (rw) {
-      x2 += rw / 2;
-    }
-  } else if (
-    xDiff > positionChangeBuffer &&
-    yDiff < 0 &&
-    Math.abs(yDiff) > positionChangeBuffer
-  ) {
-    // dispatch: top right
-    x1 += unitW;
-    // receive: bottom left
-    if (rh) {
-      y2 += rh;
-    }
-  } else if (
-    xDiff > positionChangeBuffer &&
-    Math.abs(yDiff) < positionChangeBuffer
-  ) {
-    // dispatch: center right
-    y1 += unitH / 2;
-    x1 += unitW;
-    // receive: center left
-    if (rh) {
-      y2 += rh / 2;
-    }
-  } else if (xDiff > positionChangeBuffer && yDiff > positionChangeBuffer) {
-    // dispatch: bottom right
-    y1 += unitH;
-    x1 += unitW;
-    // receive: top left
-    // nothing needs to be done for top left
-  } else if (xDiff < 0 && Math.abs(yDiff) < positionChangeBuffer) {
-    // dispatch: center left
-    y1 += unitH / 2;
-    // receive: center right
-    if (rw && rh) {
-      x2 += rw;
-      y2 += rh / 2;
-    }
-  } else if (xDiff < 0 && yDiff > positionChangeBuffer) {
-    // dispatch: bottom left
-    y1 += unitH;
-    // receive: top right
-    if (rw) {
-      x2 += rw;
-    }
+
+  // This function expects to receive the coordinates of the *upper left corners* of the
+  // dispatch and receiver, in the case when the dispatch and receiver have nonzero widths
+  // and heights.
+  // So the very first thing we need to do to compute a properly centered arrow is to center
+  // the coordinates.
+  x1 += unitW / 2;
+  y1 += unitH / 2;
+  x2 += rw / 2;
+  y2 += rh / 2;
+
+  // Next let's compute the angle that we need the arrow to go at
+  // If there isn't an angle because the diff is too small, quit out immediately
+  const xDiff = x2 - x1;
+  const yDiff = y2 - y1;
+  if (Math.abs(xDiff) <= 1e-10 && Math.abs(yDiff) <= 1e-10) {
+    return {
+      x1,
+      x2,
+      y1,
+      y2,
+    };
   }
+  const theta = Math.atan2(yDiff, xDiff);
+
+  // Make the arrow start at the border of the ellipse with the specified
+  // width and height.
+  const x1New = x1 + (unitW / 2) * Math.cos(theta);
+  const y1New = y1 + (unitH / 2) * Math.sin(theta);
+
+  // Make the arrow end at the border of the ellipse with the specified
+  // width and height.
+  const x2New = x2 - (rw / 2) * Math.cos(theta);
+  const y2New = y2 - (rh / 2) * Math.sin(theta);
+
+  // If the result would give an arrow that points backwards, due to overlap
+  // between the source and destination then give up and don't do adjustment
+  // for the source and receiver width and height.
+  // Determine if it points backwards by dot product with the original vector
+  const xDiffNew = x2New - x1New;
+  const yDiffNew = y2New - y1New;
+  if (xDiffNew * xDiff + yDiffNew * yDiff <= 1e-10) {
+    return {
+      x1,
+      x2,
+      y1,
+      y2,
+    };
+  }
+
   return {
-    x1,
-    x2,
-    y1,
-    y2,
+    x1: x1New,
+    x2: x2New,
+    y1: y1New,
+    y2: y2New,
   };
 }

--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -1,5 +1,4 @@
 import * as React from "react";
-import * as d3 from "d3";
 import ArrowColor from "../../enums/ArrowColor";
 import ArrowType from "../../enums/ArrowType";
 import Territory from "../../enums/map/variants/classic/Territory";

--- a/beta-src/src/utils/map/getUnits.ts
+++ b/beta-src/src/utils/map/getUnits.ts
@@ -8,41 +8,63 @@ import TerritoryMap, {
 } from "../../data/map/variants/classic/TerritoryMap";
 import countryMap from "../../data/map/variants/classic/CountryMap";
 import Country from "../../enums/Country";
-import { IUnit } from "../../models/Interfaces";
+import {
+  IOrderDataHistorical,
+  ITerrStatus,
+  IUnit,
+  IUnitHistorical,
+} from "../../models/Interfaces";
 import UIState from "../../enums/UIState";
 
+// What we manually construct to unify historical and live units and
+// pass down to deeper state for rendering the UI
 export interface Unit {
   country: Country;
   mappedTerritory: MTerritory;
   unit: IUnit;
+  isRetreating: boolean;
+  isDislodging: boolean;
+  movedFromTerrID: string | null;
 }
 
-export default function getUnits(
+export function getUnitsLive(
   territories: APITerritories,
+  territoryStatuses: ITerrStatus[],
   units: { [key: string]: IUnit },
   members: GameOverviewResponse["members"],
+  prevPhaseOrders: IOrderDataHistorical[],
 ): Unit[] {
   const unitsToDraw: Unit[] = [];
-  console.log({ units });
+  // console.log({ units });
+
+  const territoryStatusesByTerrID = Object.fromEntries(
+    territoryStatuses.map((territoryStatus) => [
+      territoryStatus.id,
+      territoryStatus,
+    ]),
+  );
+  const unitCountByTerrID: { [key: string]: number } = {};
+  Object.values(units).forEach((unit) => {
+    if (unit.terrID in unitCountByTerrID) {
+      unitCountByTerrID[unit.terrID] += 1;
+    } else {
+      unitCountByTerrID[unit.terrID] = 1;
+    }
+  });
+
+  // Maps current terrID => previous terrID for units that successfully moved last phase.
+  const successfulMoves: { [key: string]: string } = {};
+  prevPhaseOrders.forEach((prevOrder) => {
+    if (prevOrder.success && prevOrder.type === "Move") {
+      successfulMoves[prevOrder.toTerrID.toString()] =
+        prevOrder.terrID.toString();
+    }
+  });
+  // console.log({ prevPhaseOrders });
+  // console.log({ successfulMoves });
+
   Object.values(units).forEach((unit) => {
     const territory = territories[unit.terrID];
-    /* TODO break this for now, need to fix declaratively to get retreats to display properly
-    const territoryStatus = territoryStatuses.find((t) => unit.terrID === t.id);
-    const territoryHasMultipleUnits = Object.values(units).filter(
-      (u) => u.terrID === unit.terrID,
-    );
-
-    if (
-      territoryStatus?.occupiedFromTerrID &&
-      unit.id === territoryStatus.unitID &&
-      territoryStatus?.ownerCountryID === unit.countryID &&
-      territoryHasMultipleUnits.length > 1 &&
-      contextVars?.context.phase === "Retreats"
-    ) {
-      territory = territories[territoryStatus.occupiedFromTerrID];
-    }
-    */
-
     if (territory) {
       const mappedTerritory =
         TerritoryMap[webdipNameToTerritory[territory.name]];
@@ -52,10 +74,96 @@ export default function getUnits(
         );
         if (memberCountry) {
           const { country } = memberCountry;
+
+          const isRetreating =
+            territoryStatusesByTerrID[unit.terrID] &&
+            territoryStatusesByTerrID[unit.terrID].unitID !== null &&
+            territoryStatusesByTerrID[unit.terrID].unitID !== unit.id;
+
+          const isDislodging =
+            unitCountByTerrID[unit.terrID] >= 2 && !isRetreating;
+
+          const movedFromTerrID =
+            unit.terrID in successfulMoves
+              ? successfulMoves[unit.terrID]
+              : null;
+
           unitsToDraw.push({
             country: countryMap[country],
             mappedTerritory,
             unit,
+            isRetreating,
+            isDislodging,
+            movedFromTerrID,
+          });
+        }
+      }
+    }
+  });
+  return unitsToDraw;
+}
+
+export function getUnitsHistorical(
+  territories: APITerritories,
+  units: IUnitHistorical[],
+  members: GameOverviewResponse["members"],
+  prevPhaseOrders: IOrderDataHistorical[],
+): Unit[] {
+  const unitsToDraw: Unit[] = [];
+  console.log({ units });
+
+  const unitCountByTerrID: { [key: string]: number } = {};
+  units.forEach((unit) => {
+    if (unit.terrID in unitCountByTerrID) {
+      unitCountByTerrID[unit.terrID] += 1;
+    } else {
+      unitCountByTerrID[unit.terrID] = 1;
+    }
+  });
+
+  // Maps current terrID => previous terrID for units that successfully moved last phase.
+  const successfulMoves: { [key: string]: string } = {};
+  prevPhaseOrders.forEach((prevOrder) => {
+    if (prevOrder.success && prevOrder.type === "Move") {
+      successfulMoves[prevOrder.toTerrID.toString()] =
+        prevOrder.terrID.toString();
+    }
+  });
+  units.forEach((unit, index) => {
+    const territory = territories[unit.terrID];
+    const iUnit = {
+      id: index.toString(),
+      countryID: unit.countryID.toString(),
+      type: unit.unitType,
+      terrID: unit.terrID.toString(),
+    };
+
+    if (territory) {
+      const mappedTerritory =
+        TerritoryMap[webdipNameToTerritory[territory.name]];
+      if (mappedTerritory) {
+        const memberCountry = members.find(
+          (member) => member.countryID.toString() === iUnit.countryID,
+        );
+        if (memberCountry) {
+          const { country } = memberCountry;
+
+          const isRetreating = unit.retreating === "Yes";
+          const isDislodging =
+            unitCountByTerrID[unit.terrID] >= 2 && !isRetreating;
+
+          const movedFromTerrID =
+            unit.terrID in successfulMoves
+              ? successfulMoves[unit.terrID]
+              : null;
+
+          unitsToDraw.push({
+            country: countryMap[country],
+            mappedTerritory,
+            unit: iUnit,
+            isRetreating,
+            isDislodging,
+            movedFromTerrID,
           });
         }
       }

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -58,6 +58,7 @@ export default function fetchGameDataFulfilled(state: GameState, action): void {
     data.units,
     members,
     prevPhaseOrders,
+    state.ordersMeta,
   );
 
   state.territoriesMeta = getTerritoriesMeta(data);

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled.ts
@@ -48,5 +48,6 @@ export default function fetchGameStatusFulfilled(
     data.units,
     members,
     prevPhaseOrders,
+    state.ordersMeta,
   );
 }


### PR DESCRIPTION
Work in progress.

* Overhauls the arrow coordinate positioning code, throwing out and rewriting some very buggy numerical logic and replacing it with a much simpler angle-based method.
* Draw retreat arrows
* On retreats, draw the dislodger unit at the arrow receiver position along with that unit's movement arrow so that you can see what unit caused the dislodgment of the retreating unit.
* Draw builds and functionalize the builds data for drawing.
* Also draw an extra green circle around all the builds since otherwise they're way too hard to see.

Remaining TODO: 
* Draw disbands
* Make arrow receivers for all the coasts and fix up the drawing logic for coastal everything.

After that, historical view and order drawing should basically be done. We can always change the colors and such according to the new spec we want (to rely less on color and more on shape) but we'll basically be functional enough.
