### PR TITLE
holy moly convoys working

### DIFF
--- a/beta-src/src/components/map/components/WDFlyoutContainer.tsx
+++ b/beta-src/src/components/map/components/WDFlyoutContainer.tsx
@@ -4,12 +4,15 @@ import { Box, Button, Stack } from "@mui/material";
 import Territories from "../../../data/Territories";
 import {
   gameApiSliceActions,
+  gameBoard,
   gameMaps,
   gameOrder,
 } from "../../../state/game/game-api-slice";
 import { useAppDispatch, useAppSelector } from "../../../state/hooks";
 import Territory from "../../../enums/map/variants/classic/Territory";
 import { Unit } from "../../../utils/map/getUnits";
+import isConvoyable from "../../../utils/state/isConvoyable";
+
 import WDFlyoutButton from "./WDFlyoutButton";
 
 interface WDFlyoutContainerProps {
@@ -22,6 +25,7 @@ const WDFlyoutContainer: React.FC<WDFlyoutContainerProps> = function ({
   const dispatch = useAppDispatch();
   const order = useAppSelector(gameOrder);
   const maps = useAppSelector(gameMaps);
+  const board = useAppSelector(gameBoard);
 
   console.log({ order });
 
@@ -33,14 +37,17 @@ const WDFlyoutContainer: React.FC<WDFlyoutContainerProps> = function ({
 
   const territory = maps.terrIDToTerritory[maps.unitToTerrID[order.unitID]];
   const unitSlotName = "main"; // FIXME
-  const clickHandler = (orderType) => () => {
-    console.log(`Dispatched ${orderType}`);
-    dispatch(
-      gameApiSliceActions.updateOrder({
-        type: orderType,
-      }),
-    );
-  };
+  const clickHandler =
+    (orderType, viaConvoy: string | undefined = undefined) =>
+    () => {
+      console.log(`Dispatched ${orderType}`);
+      dispatch(
+        gameApiSliceActions.updateOrder({
+          type: orderType,
+          viaConvoy,
+        }),
+      );
+    };
 
   return (
     <>
@@ -74,6 +81,15 @@ const WDFlyoutContainer: React.FC<WDFlyoutContainerProps> = function ({
           clickHandler={clickHandler("Convoy")}
         />
       )) || <g />}
+      {board && isConvoyable(board, unit) && (
+        <WDFlyoutButton
+          territory={territory}
+          unitSlotName={unitSlotName}
+          position="bottom"
+          text="Via"
+          clickHandler={clickHandler("Move", "Yes")}
+        />
+      )}
     </>
   );
 };

--- a/beta-src/src/components/map/components/WDTerritory.tsx
+++ b/beta-src/src/components/map/components/WDTerritory.tsx
@@ -107,6 +107,11 @@ const WDTerritory: React.FC<WDTerritoryProps> = function ({
       }
       if (curOrder.fromTerrID === territoryMeta?.id) {
         territoryFillOpacity = 0.7;
+        // yuck
+        const ownerCountry = members.find(
+          (m) => m.countryID === Number(territoryMeta.ownerCountryID),
+        )?.country;
+        territoryFill = theme.palette[ownerCountry || ""]?.main;
       }
       const wdUnit = (
         <WDUnit

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -332,6 +332,7 @@ export const gameTerritoriesMeta = ({
   game: { territoriesMeta },
 }: RootState): TerritoriesMeta => territoriesMeta;
 export const gameMaps = ({ game: { maps } }: RootState) => maps;
+export const gameBoard = ({ game: { board } }: RootState) => board;
 export const gameViewedPhase = ({
   game: { viewedPhaseState },
 }: RootState): ViewedPhaseState => viewedPhaseState;

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -30,6 +30,7 @@ const initialState: GameState = {
     orderID: "",
     toTerrID: "",
     unitID: "",
+    viaConvoy: "",
   },
   ordersMeta: {},
   ownUnits: [],

--- a/beta-src/src/state/interfaces/GameDataResponse.ts
+++ b/beta-src/src/state/interfaces/GameDataResponse.ts
@@ -10,7 +10,7 @@ export interface APITerritories {
   [key: string]: ITerritory;
 }
 
-interface GameData {
+export interface GameData {
   contextVars?: ContextVar;
   currentOrders?: IOrderData[];
   territories: APITerritories;

--- a/beta-src/src/state/interfaces/OrderState.ts
+++ b/beta-src/src/state/interfaces/OrderState.ts
@@ -8,6 +8,7 @@ export interface OrderState {
   unitID: string;
   fromTerrID: string;
   toTerrID: string;
+  viaConvoy: string;
 }
 
 export default OrderState;

--- a/beta-src/src/utils/state/getDataForOrder.ts
+++ b/beta-src/src/utils/state/getDataForOrder.ts
@@ -17,6 +17,7 @@ export default function getDataForOrder(
     toTerrID,
     unitID,
     type,
+    viaConvoy: "",
   };
   return newOrder;
 }

--- a/beta-src/src/utils/state/isConvoyable.ts
+++ b/beta-src/src/utils/state/isConvoyable.ts
@@ -1,0 +1,18 @@
+import { Unit } from "../map/getUnits";
+import BoardClass from "../../models/BoardClass";
+import { UnitType } from "../../models/enums";
+
+/* eslint-disable no-param-reassign */
+export default function isConvoyable(board: BoardClass, unit?: Unit): boolean {
+  // to be convoyable, the unit needs to be an army adjacent to a fleet in water
+  if (!unit) return false;
+  if (unit.unit.type !== "Army") return false;
+  const unitTerr = board.findUnitByID(unit.unit.id);
+  return unitTerr?.Territory.convoyLink || false;
+  // const borderUnits = board.getBorderUnits(unitTerr);
+  // console.log({ borderUnits });
+  // const borderWaterFleets = borderUnits.filter(
+  //   (u) => u.type === UnitType.Fleet && u.Territory.type === "Sea",
+  // );
+  // return !!borderWaterFleets.length;
+}

--- a/beta-src/src/utils/state/processConvoy.ts
+++ b/beta-src/src/utils/state/processConvoy.ts
@@ -23,11 +23,13 @@ export default function processConvoy(state: GameState, evt): boolean {
   const orderUnit = board.findUnitByID(order.unitID);
   const unitTerrID = maps.unitToTerrID[order.unitID];
   const againstTerritory = board.findTerritoryByID(toTerrID);
+  if (!againstTerritory) throw Error();
   let convoyPath;
   if (order.type === "Convoy") {
     const fleetOrder = currentOrders?.find((o) => o.unitID === order.unitID);
     const convoyOrder = new OrderClass(board, fleetOrder!, orderUnit!);
     const convoyArmy = board.units.find((c) => c.terrID === order.fromTerrID);
+    if (!convoyArmy || convoyArmy.type !== "Army") throw Error();
     const fromTerritory = board.findTerritoryByID(fromTerrID);
     console.log({
       fromTerritory,
@@ -41,6 +43,7 @@ export default function processConvoy(state: GameState, evt): boolean {
     );
   } else if (order.type === "Move") {
     const convoyArmy = board.units.find((c) => c.id === order.unitID);
+    if (!convoyArmy || convoyArmy.type !== "Army") throw Error();
     convoyPath = convoyArmy?.ConvoyGroup.pathArmyToCoast(
       board.findTerritoryByID(unitTerrID),
       againstTerritory,

--- a/beta-src/src/utils/state/processConvoy.ts
+++ b/beta-src/src/utils/state/processConvoy.ts
@@ -3,96 +3,56 @@ import Territory from "../../enums/map/variants/classic/Territory";
 import OrderClass from "../../models/OrderClass";
 import updateOrdersMeta from "./updateOrdersMeta";
 import invalidClick from "../map/invalidClick";
+import updateOrder from "./updateOrder";
+import { GameState } from "../../state/interfaces/GameState";
 
 /* eslint-disable no-param-reassign */
-export default function processConvoy(state, evt): void {
+export default function processConvoy(state: GameState, evt): boolean {
   const {
     board,
     data: {
       data: { currentOrders },
     },
     order,
-    ordersMeta,
     maps,
   } = current(state);
-  const lastFleetInChain =
-    order.subsequentClicks[order.subsequentClicks.length - 1];
-  if (lastFleetInChain) {
-    const { convoyToChoices } = ordersMeta[lastFleetInChain.order];
-    const toTerritory = maps.enumToTerritory[order.toTerritory];
-    const fromTerritory = maps.enumToTerritory[order.onTerritory];
+  // eslint-disable-next-line no-debugger
 
-    if (convoyToChoices.includes(toTerritory)) {
-      const orderUnit = board.findUnitByID(lastFleetInChain.unitID);
-      const fleetOrder = currentOrders?.find(
-        (o) => o.unitID === lastFleetInChain.unitID,
-      );
-      if (fleetOrder) {
-        const convoyOrder = new OrderClass(board, fleetOrder, orderUnit);
-        const againstTerritory = board.findTerritoryByID(toTerritory);
-        const convoyFrom = convoyOrder.getConvoyFromChoices(againstTerritory);
-        const convoyArmy = convoyFrom.find((c) => c.id === order.unitID);
-        if (convoyArmy) {
-          const convoyPath = convoyArmy.ConvoyGroup.pathArmyToCoastWithFleet(
-            board.findTerritoryByID(fromTerritory),
-            againstTerritory,
-            convoyOrder.unit.Territory,
-          );
-          if (convoyPath) {
-            const clickedUnitsTerritories = order.subsequentClicks.map(
-              (click) => {
-                return maps.enumToTerritory[click.onTerritory];
-              },
-            );
-            clickedUnitsTerritories.push(
-              maps.enumToTerritory[order.onTerritory],
-            );
-            const updates = {};
-            convoyPath.forEach((terrID) => {
-              let foundClick =
-                maps.enumToTerritory[order.onTerritory] === terrID
-                  ? order
-                  : false;
-              if (!foundClick) {
-                foundClick = order.subsequentClicks.find((click) => {
-                  return maps.enumToTerritory[click.onTerritory] === terrID;
-                });
-              }
-              if (!foundClick) {
-                // user did not click this unit
-              } else {
-                const unitOrderID = maps.unitToOrder[foundClick.unitID];
-                const unitIsArmy =
-                  board.findUnitByID(foundClick.unitID).type === "Army";
-                if (unitIsArmy) {
-                  updates[unitOrderID] = {
-                    saved: false,
-                    update: {
-                      convoyPath,
-                      toTerrID: toTerritory,
-                      type: "Move",
-                      viaConvoy: "Yes",
-                    },
-                  };
-                } else {
-                  updates[unitOrderID] = {
-                    saved: false,
-                    update: {
-                      convoyPath,
-                      toTerrID: toTerritory,
-                      fromTerrID: fromTerritory,
-                      type: "Convoy",
-                    },
-                  };
-                }
-              }
-            });
-            updateOrdersMeta(state, updates);
-          }
-        }
-      }
-      return;
-    }
+  const { fromTerrID, toTerrID } = order;
+  if (!board) throw Error();
+  const orderUnit = board.findUnitByID(order.unitID);
+  const unitTerrID = maps.unitToTerrID[order.unitID];
+  const againstTerritory = board.findTerritoryByID(toTerrID);
+  let convoyPath;
+  if (order.type === "Convoy") {
+    const fleetOrder = currentOrders?.find((o) => o.unitID === order.unitID);
+    const convoyOrder = new OrderClass(board, fleetOrder!, orderUnit!);
+    const convoyArmy = board.units.find((c) => c.terrID === order.fromTerrID);
+    const fromTerritory = board.findTerritoryByID(fromTerrID);
+    console.log({
+      fromTerritory,
+      againstTerritory,
+      unitTerr: convoyOrder.unit.Territory,
+    });
+    convoyPath = convoyArmy?.ConvoyGroup?.pathArmyToCoastWithFleet(
+      fromTerritory,
+      againstTerritory,
+      convoyOrder.unit.Territory,
+    );
+  } else if (order.type === "Move") {
+    const convoyArmy = board.units.find((c) => c.id === order.unitID);
+    convoyPath = convoyArmy?.ConvoyGroup.pathArmyToCoast(
+      board.findTerritoryByID(unitTerrID),
+      againstTerritory,
+    );
+  } else {
+    throw Error();
   }
-  invalidClick(evt, Territory[order.toTerritory]); // not sure if this is the right specification of Territory
+
+  if (convoyPath) {
+    updateOrder(state, {
+      convoyPath,
+    });
+  }
+  return !!convoyPath;
 }

--- a/beta-src/src/utils/state/updateOrder.ts
+++ b/beta-src/src/utils/state/updateOrder.ts
@@ -10,6 +10,19 @@ interface OrderUpdate {
   viaConvoy?: string | null;
   orderID?: string | null;
   inProgress?: boolean;
+  convoyPath?: any;
+}
+
+function isOrderReady(order: OrderUpdate): boolean {
+  if (!order.type) return false;
+  if (["Hold", "Destroy", "Disband"].includes(order.type)) return true;
+  if (order.type === "Build") return false; // handled by popup
+  if (order.toTerrID) {
+    if (order.type === "Convoy" || order.viaConvoy === "Yes")
+      return order.convoyPath;
+    return true;
+  }
+  return false;
 }
 /* eslint-disable no-param-reassign */
 export default function updateOrder(state, update: OrderUpdate): void {
@@ -21,10 +34,7 @@ export default function updateOrder(state, update: OrderUpdate): void {
   // gotta do this carefully because the proxying
   // system gets confused if I update state.order
   // and then commit state.order
-  if (
-    ["Hold", "Destroy", "Disband"].includes(newOrder.type) ||
-    (newOrder.type && newOrder.type !== "Build" && newOrder.toTerrID)
-  ) {
+  if (isOrderReady(newOrder)) {
     commitOrder(state, newOrder);
   } else {
     state.order = newOrder;


### PR DESCRIPTION
It turns out that webdip requires you to compute the convoy path on the client side! Luckily, codazen had implemented the logic already. This could use a codazen review but seems to work in simple situations.

- Convoys and convoy moves can be sucessfully entered now
- Added a separate flyout for "Via", so you can specify via land or via convoy moves
- Fixed valid destinations for retreats
- Fixed valid sources for supports.