### PR TITLE
Keep info table in order

### DIFF
--- a/beta-src/src/components/ui/WDUI.tsx
+++ b/beta-src/src/components/ui/WDUI.tsx
@@ -70,6 +70,7 @@ const WDUI: React.FC = function (): React.ReactElement {
       countries.push(constructTableData(member));
     }
   });
+  countries.sort((x, y) => x.countryID - y.countryID);
 
   const userTableData = constructTableData(user.member);
 


### PR DESCRIPTION
The country name order in info table were changing after every refresh.