### PR TITLE
Make the countdown timer no longer cause rerenders every second

### DIFF
--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -97,7 +97,6 @@ const WDMapController: React.FC = function (): React.ReactElement {
           originalOrder = currentOrdersById[orderID];
         }
         if (originalOrder) {
-          console.log({ originalOrder });
           if (originalOrder.fromTerrID) {
             fromTerrID = Number(originalOrder.fromTerrID);
           }

--- a/beta-src/src/components/ui/WDCountdownPill.tsx
+++ b/beta-src/src/components/ui/WDCountdownPill.tsx
@@ -56,7 +56,7 @@ const WDCountdownPill: React.FC<WDCountdownPillProps> = function ({
     }, 1000);
 
     return () => clearInterval(timer);
-  }, []);
+  }, [endTime]);
 
   const isTimeRunningOut = +new Date() > quarterTimeRemaining;
   const shouldDisplayGamePhase =

--- a/beta-src/src/components/ui/WDCountdownPill.tsx
+++ b/beta-src/src/components/ui/WDCountdownPill.tsx
@@ -22,6 +22,12 @@ interface WDCountdownPillProps {
 
 const milli = 1000;
 
+const getFormattedTimeLeft = function (endTime: number) {
+  const secondsLeft = endTime - +new Date() / milli;
+  const timeLeft = parseSeconds(secondsLeft);
+  return formatTime(timeLeft);
+};
+
 const WDCountdownPill: React.FC<WDCountdownPillProps> = function ({
   endTime,
   phaseTime,
@@ -39,26 +45,25 @@ const WDCountdownPill: React.FC<WDCountdownPillProps> = function ({
   const quarterTimeRemaining =
     endTimeInMilliSeconds - phaseTimeInMilliSeconds / 4;
 
-  const secondsLeft = endTime - +new Date() / milli;
-
-  const [timeLeft, setTimeLeft] = useState<ParsedTime>(
-    parseSeconds(secondsLeft),
+  const [formattedTimeLeft, setFormattedTimeLeft] = useState<string>(
+    getFormattedTimeLeft(endTime),
   );
 
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setTimeLeft(parseSeconds(secondsLeft));
+    const timer = setInterval(() => {
+      const newFormattedTimeLeft = getFormattedTimeLeft(endTime);
+      setFormattedTimeLeft(newFormattedTimeLeft);
     }, 1000);
 
-    return () => clearTimeout(timer);
-  }, [secondsLeft]);
+    return () => clearInterval(timer);
+  }, []);
 
   const isTimeRunningOut = +new Date() > quarterTimeRemaining;
   const shouldDisplayGamePhase =
     viewedPhase !== gamePhase ||
     viewedSeason !== gameSeason ||
     viewedYear !== gameYear;
-  let chipDisplay: string = formatTime(timeLeft);
+  let chipDisplay: string = formattedTimeLeft;
   if (shouldDisplayGamePhase) {
     chipDisplay += ` for ${gameSeason} ${gameYear} ${formatPhaseForDisplay(
       gamePhase,


### PR DESCRIPTION
This is probably not where our performance issues and memory leaking was coming from... but it was still good practice for cleaning things up and understanding how react decides to rerender stuff.

This PR makes it so that the timer in the upper left corner no longer causes a rerender every second. It now only causes a rerender when the actual displayed contents of the timer *changes*, which for example might be only every minute or every hour depending on the resolution of the clock given the time remaining.
