### PR TITLE
No messages poll rerender

### DIFF
--- a/beta-src/src/components/ui/WDPress.tsx
+++ b/beta-src/src/components/ui/WDPress.tsx
@@ -55,7 +55,7 @@ const WDPress: React.FC<WDPressProps> = function ({
   const { user, gameID } = useAppSelector(gameOverview);
   const messages = useAppSelector(({ game }) => game.messages.messages);
   const newMessagesFrom = useAppSelector(
-   ({ game }) => game.messages.newMessagesFrom,
+    ({ game }) => game.messages.newMessagesFrom,
   );
 
   // FIXME: for now, crazily fetch all messages every 1sec

--- a/beta-src/src/components/ui/WDPress.tsx
+++ b/beta-src/src/components/ui/WDPress.tsx
@@ -20,11 +20,11 @@ import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import {
   fetchGameMessages,
   gameApiSliceActions,
-  gameMessages,
   gameOverview,
   markMessagesSeen,
   sendMessage,
 } from "../../state/game/game-api-slice";
+import { store } from "../../state/store";
 
 interface WDPressProps {
   children: React.ReactNode;
@@ -53,23 +53,28 @@ const WDPress: React.FC<WDPressProps> = function ({
   );
 
   const { user, gameID } = useAppSelector(gameOverview);
-  const messages = useAppSelector(gameMessages);
-  const outstandingRequests = useAppSelector(
-    ({ game: { outstandingMessageRequests } }) => outstandingMessageRequests,
+  const messages = useAppSelector(({ game }) => game.messages.messages);
+  const newMessagesFrom = useAppSelector(
+   ({ game }) => game.messages.newMessagesFrom,
   );
+
   // FIXME: for now, crazily fetch all messages every 1sec
   useInterval(() => {
-    if (user && gameID && messages && outstandingRequests === 0) {
-      console.log("Dispatching");
-      dispatch(gameApiSliceActions.updateOutstandingMessageRequests(1));
-      dispatch(
-        fetchGameMessages({
-          gameID: gameID as unknown as string,
-          countryID: user.member.countryID as unknown as string,
-          allMessages: "true",
-          sinceTime: messages.time as unknown as string,
-        }),
-      );
+    if (user && gameID) {
+      const { game } = store.getState();
+      const { outstandingMessageRequests } = game;
+      if (outstandingMessageRequests === 0) {
+        console.log("Dispatching");
+        dispatch(gameApiSliceActions.updateOutstandingMessageRequests(1));
+        dispatch(
+          fetchGameMessages({
+            gameID: gameID as unknown as string,
+            countryID: user.member.countryID as unknown as string,
+            allMessages: "true",
+            sinceTime: game.messages.time as unknown as string,
+          }),
+        );
+      }
     }
   }, 1000);
 
@@ -101,7 +106,7 @@ const WDPress: React.FC<WDPressProps> = function ({
     }
   };
 
-  if (messages.newMessagesFrom.includes(countryIDSelected)) {
+  if (newMessagesFrom.includes(countryIDSelected)) {
     // need to update locally and on the server
     // because we don't immediately re-fetch message data from the server
     dispatch(gameApiSliceActions.processMessagesSeen(countryIDSelected));
@@ -131,11 +136,7 @@ const WDPress: React.FC<WDPressProps> = function ({
             countryIDSelected === country.countryID ? "contained" : "text"
           }
           startIcon={
-            messages.newMessagesFrom.includes(country.countryID) ? (
-              <Email />
-            ) : (
-              ""
-            )
+            newMessagesFrom.includes(country.countryID) ? <Email /> : ""
           }
         >
           {country.country.slice(0, 3).toUpperCase()}
@@ -151,7 +152,7 @@ const WDPress: React.FC<WDPressProps> = function ({
         </ButtonGroup>
       </Stack>
       <WDMessageList
-        messages={messages.messages}
+        messages={messages}
         countries={[...countries, userCountry]} // sorry, its just silly to exclude userCountry from this table
         userCountry={userCountry}
         countryIDSelected={countryIDSelected}

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -30,6 +30,7 @@ import TerritoriesMeta from "../interfaces/TerritoriesState";
 import fetchGameOverviewFulfilled from "../../utils/state/gameApiSlice/extraReducers/fetchGameOverview/fulfilled";
 import fetchGameStatusFulfilled from "../../utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled";
 import saveOrdersFulfilled from "../../utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled";
+import shallowArraysEqual from "../../utils/shallowArraysEqual";
 
 export const fetchGameData = createAsyncThunk(
   ApiRoute.GAME_DATA,
@@ -293,9 +294,22 @@ const gameApiSlice = createSlice({
             }
           }
           if (newMessagesFrom) {
-            state.messages.newMessagesFrom = newMessagesFrom;
+            // Only use the new newMessagesFrom if it has distinct values
+            // Otherwise, use the old value to preserve reference equality
+            // so that selectors recognize nothing changed and less of the UI
+            // needs to redraw
+            if (
+              !shallowArraysEqual(
+                state.messages.newMessagesFrom,
+                newMessagesFrom,
+              )
+            ) {
+              state.messages.newMessagesFrom = newMessagesFrom;
+            }
           }
-          console.log(`time=${time}`);
+          console.log(
+            `time=${time}, outstandingMessageRequests=${state.outstandingMessageRequests}`,
+          );
           if (time) {
             state.messages.time = time;
           }
@@ -326,8 +340,13 @@ export const gameOrder = ({ game: { order } }: RootState): OrderState => order;
 export const userActivity = ({
   game: { activity },
 }: RootState): GameState["activity"] => activity;
-export const gameMessages = ({ game: { messages } }: RootState): GameMessages =>
-  messages;
+// gameMessages considered harmful, because part of the GameMessages object is a
+// counter that tracks the last query timestamp, which means that if you use this
+// selector rather than a more specific one, your component will update basically
+// every time the server is queries for messages, regardless of whether
+// the messages changed or not.
+// export const gameMessages = ({ game: { messages } }: RootState): GameMessages =>
+//  messages;
 export const gameTerritoriesMeta = ({
   game: { territoriesMeta },
 }: RootState): TerritoriesMeta => territoriesMeta;

--- a/beta-src/src/utils/shallowArraysEqual.ts
+++ b/beta-src/src/utils/shallowArraysEqual.ts
@@ -1,0 +1,15 @@
+export default function shallowArraysEqual(a: any[], b: any[]): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  for (let i = 0; i < a.length; i += 1) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}


### PR DESCRIPTION
Don't rerender messages UI every time we poll for messages. Only do so when the messages changed.

Also, we fix some bugs, where we were grabbing values like outstandingMessageRequests and messages.time and using them inside a setInterval, where they could become outdated. Instead we grab these values inside the setInterval now so they are fresh.

Finally with this change, the react UI is basically quiescent if you aren't doing anything. It's still doing a ton of polling of course and putting load on the server, but react basically will basically be quiet and a typical multi-second stretch of the profiler captures 0 renders now.

