### PR TITLE
Add better visual indicator for destroy phase

### DIFF
--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -177,6 +177,8 @@ const WDMapController: React.FC = function (): React.ReactElement {
         prevPhaseOrders,
         ordersMeta,
         data.data.currentOrders ? data.data.currentOrders : [],
+        overview.user,
+        overview.phase,
       );
 
       const centersByProvince: { [key: string]: { ownerCountryID: string } } =


### PR DESCRIPTION
Make it so that units look get drawn with a red stripey just like dislodged in a retreat phase, during a destroy phase. Until you select enough units to destroy, then they get drawn normally.

Maybe redundant with the little icons you recently added on the right? Or still a good supplemental visual effect?

![image](https://user-images.githubusercontent.com/11942395/171220981-2e29123a-b0c1-4e46-8897-6152868299ba.png)

=>

![image](https://user-images.githubusercontent.com/11942395/171221159-6dc62291-2a6c-4fdb-b30f-50c1ffa84bde.png)
