### PR TITLE
Make the title not React App

### DIFF
--- a/beta-src/public/index.html
+++ b/beta-src/public/index.html
@@ -24,7 +24,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <title>React App</title>
+    <title>webDiplomacy Game Map</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/beta-src/src/components/controllers/WDMainController.tsx
+++ b/beta-src/src/components/controllers/WDMainController.tsx
@@ -1,5 +1,6 @@
 import { Box } from "@mui/material";
 import * as React from "react";
+import { useEffect } from "react";
 import {
   fetchGameOverview,
   gameApiSliceActions,
@@ -53,6 +54,11 @@ const WDMainController: React.FC = function ({ children }): React.ReactElement {
       }),
     );
   }, 500);
+
+  const { name, gameID } = overview;
+  useEffect(() => {
+    document.title = `${name} - webDiplomacy Game ${gameID}`;
+  }, [name, gameID]);
 
   if (!consistentPhase) {
     return <Box>Loading...</Box>;


### PR DESCRIPTION
The title used to be "React App".
We set it to a better thing by default in index.html, and then when the page loads for real we set it to something based on the name and id of the game.