### PR TITLE
Treat very tiny drags as clicks

### DIFF
--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -262,6 +262,7 @@ const WDMapController: React.FC = function (): React.ReactElement {
           [mapOriginalWidth, mapOriginalHeight],
         ])
         .scaleExtent([scale, scaleMax])
+        .clickDistance(3)
         .on("zoom", zoom);
 
       fullMap


### PR DESCRIPTION
I find that if my mouse is moving very slightly in the time between mouse down and mouse up, a click doesn't register. So treat drags that move the screen less than 3 pixels as clicks.