### PR TITLE
Color all non-sea provinces by ownerID

### DIFF
--- a/api/responses/game_state.php
+++ b/api/responses/game_state.php
@@ -351,7 +351,7 @@ class GameState {
 				  FROM wD_Territories t
 				  JOIN wD_TerrStatusArchive ts
 				  ON ( ts.terrID = t.id )
-				  WHERE ts.gameID = ".$this->gameID." AND t.supply = 'Yes' AND t.mapID=".$mapID
+				  WHERE ts.gameID = ".$this->gameID." AND t.mapID=".$mapID
 		);
 		while ($row = $DB->tabl_hash($centersTabl)) {
 			$inGameCenters[intval($row['turn'])][] = new Territory($row['id'], $row['countryID']);

--- a/api/responses/game_state.php
+++ b/api/responses/game_state.php
@@ -339,7 +339,7 @@ class GameState {
 		$preGameCentersTabl = $DB->sql_tabl(
 			"SELECT t.id, t.countryID
 				  FROM wD_Territories t
-				  WHERE t.supply = 'Yes' AND t.mapID = ".$mapID
+				  WHERE t.mapID = ".$mapID
 		);
 		while ($row = $DB->tabl_hash($preGameCentersTabl)) {
 			array_push($preGameCenters, new Territory($row['id'], $row['countryID']));

--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -185,10 +185,8 @@ const WDMapController: React.FC = function (): React.ReactElement {
         {};
       data.data.territoryStatuses.forEach((provinceStatus) => {
         const province = maps.terrIDToProvince[provinceStatus.id];
-        if (provincesMapData[province].centerPos) {
-          const ownerCountryID = provinceStatus.ownerCountryID || "0";
-          centersByProvince[province] = { ownerCountryID };
-        }
+        const ownerCountryID = provinceStatus.ownerCountryID || "0";
+        centersByProvince[province] = { ownerCountryID };
       });
 
       return {
@@ -298,7 +296,6 @@ const WDMapController: React.FC = function (): React.ReactElement {
     return () => window.removeEventListener("keydown", keydownHandler);
   });
 
-  console.log("Renderd MapController");
   return (
     <div
       style={{

--- a/beta-src/src/components/map/components/WDProvince.tsx
+++ b/beta-src/src/components/map/components/WDProvince.tsx
@@ -38,11 +38,11 @@ const WDProvince: React.FC<WDProvinceProps> = function ({
   const territoryStrokeOpacity = 1;
 
   // Normally, color according to supply center ownership
-  if (ownerCountryID && provinceMapData.centerPos) {
+  if (ownerCountryID) {
     const ownerCountry = members.find(
       (m) => m.countryID === Number(ownerCountryID),
     )?.country;
-    if (ownerCountry) {
+    if (ownerCountry && provinceMapData.type !== "Sea") {
       territoryFill = theme.palette[ownerCountry]?.main;
       territoryFillOpacity = 0.4;
     }

--- a/beta-src/src/components/ui/WDCountdownPill.tsx
+++ b/beta-src/src/components/ui/WDCountdownPill.tsx
@@ -42,7 +42,6 @@ const WDCountdownPill: React.FC<WDCountdownPillProps> = function ({
   const endTimeInMilliSeconds = endTime * milli;
   const phaseTimeInMilliSeconds = phaseTime * milli;
   const [viewport] = useViewport();
-  console.log({ viewport });
   const quarterTimeRemaining =
     endTimeInMilliSeconds - phaseTimeInMilliSeconds / 4;
 

--- a/beta-src/src/utils/state/updateOrdersMeta.ts
+++ b/beta-src/src/utils/state/updateOrdersMeta.ts
@@ -2,13 +2,9 @@ import { EditOrderMeta } from "../../state/interfaces/SavedOrders";
 
 /* eslint-disable no-param-reassign */
 export default function updateOrdersMeta(state, updates: EditOrderMeta): void {
-  console.log("updateOrdersMeta");
-  console.log({ updates });
   const entries = Object.entries(updates);
   if (entries.length) {
     entries.forEach(([orderID, update]) => {
-      console.log({ orderID, order: state.ordersMeta[orderID], update });
-
       state.ordersMeta[orderID] = {
         ...state.ordersMeta[orderID],
         ...update,


### PR DESCRIPTION
Color every territory by owner. This required a tiny change on the backend to report owners for every territory instead of SCs only.

The bad news is that the variable in the API response is still "centers" even though it's now for all provinces. Should we make this a larger change by renaming this variable?

Before:

<img width="894" alt="image" src="https://user-images.githubusercontent.com/5702157/171282470-79eb0da5-fa76-49ab-ba48-55ea1f0bae69.png">

After (Historical phase):

<img width="1145" alt="image" src="https://user-images.githubusercontent.com/5702157/171282333-1f4a2d89-94a6-4f8a-9856-82f2ac9ad1ee.png">

After (Current phase):

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/5702157/171282363-c9ea91b2-4150-4814-a792-83b2d5d0d92f.png">
