### PR TITLE
Fix a crash for supports

### DIFF
--- a/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
@@ -279,8 +279,7 @@ export default function processMapClick(
       // click 1
       if (
         clickUnitID &&
-        legalOrders.legalSupportsByUnitID[order.unitID][clickProvince] &&
-        legalOrders.legalSupportsByUnitID[order.unitID][clickProvince].length >
+        legalOrders.legalSupportsByUnitID[order.unitID][clickProvince]?.length >
           0
       ) {
         updateOrder(state, {


### PR DESCRIPTION
Fix a crash that happens if you click a unit, click support, and then try to click a supportee that you're not allow to support.