### PR TITLE
Fix key for build icons

### DIFF
--- a/beta-src/src/components/ui/WDBuildCounts.tsx
+++ b/beta-src/src/components/ui/WDBuildCounts.tsx
@@ -43,21 +43,19 @@ const WDBuildCounts: React.FC = function (): React.ReactElement {
     >
       <Stack>
         {range(numRemainingBuilds).map((buildIdx) => (
-          <svg style={{ height: UNIT_HEIGHT, width: UNIT_WIDTH_SQUOOSHED }}>
-            <WDArmyIcon
-              key={buildIdx}
-              country={Country.FRANCE}
-              iconState={UIState.BUILD}
-            />
+          <svg
+            key={buildIdx}
+            style={{ height: UNIT_HEIGHT, width: UNIT_WIDTH_SQUOOSHED }}
+          >
+            <WDArmyIcon country={Country.FRANCE} iconState={UIState.BUILD} />
           </svg>
         ))}
         {range(numRemainingDestroys).map((buildIdx) => (
-          <svg style={{ height: UNIT_HEIGHT, width: UNIT_WIDTH_SQUOOSHED }}>
-            <WDArmyIcon
-              key={buildIdx}
-              country={Country.FRANCE}
-              iconState={UIState.DESTROY}
-            />
+          <svg
+            key={buildIdx}
+            style={{ height: UNIT_HEIGHT, width: UNIT_WIDTH_SQUOOSHED }}
+          >
+            <WDArmyIcon country={Country.FRANCE} iconState={UIState.DESTROY} />
           </svg>
         ))}
       </Stack>


### PR DESCRIPTION
React is complaining about things in a list not having a unique key prop.
We fix that here. The bug was that key was being specified on the inner thing inside the svg, but those weren't the things being put into a list, instead it was the outer SVG element. So we need to specify the key there instead.