### PR TITLE
Fix destroy actions and maybe disband actions for coasts

### DIFF
--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -179,6 +179,7 @@ const WDMapController: React.FC = function (): React.ReactElement {
         data.data.currentOrders ? data.data.currentOrders : [],
         overview.user,
         overview.phase,
+        maps,
       );
 
       const centersByProvince: { [key: string]: { ownerCountryID: string } } =
@@ -210,6 +211,7 @@ const WDMapController: React.FC = function (): React.ReactElement {
       overview.members,
       prevPhaseOrders,
       phaseHistorical.orders,
+      maps,
     );
     const centersByProvince: {
       [key: string]: { ownerCountryID: string };

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
@@ -178,7 +178,8 @@ export default function processMapClick(
         invalidClick(evt, clickProvince);
         return;
       }
-      toTerrID = clickUnit.terrID;
+      // Webdip API expects that destroy actions are in terms of province ID, not territory ID!
+      toTerrID = maps.terrIDToProvinceID[clickUnit.terrID];
     } else if (isBuild) {
       // Build on the appropriately clicked coast for STP
       const territory = getBestCoastalUnitTerritory(evt, clickProvinceMapData);


### PR DESCRIPTION
Fix the bug that Noam reported, where destroying a fleet on STP doesn't draw correctly. It also doesn't input correctly if you are Russia yourself and you try to save orders.

The reason appears to be that destroys of fleets on special coasts are expected by the webdip API to be inputted as a destroy for the *province* of the unit, i.e. it wants you to provide the territory ID of the root territory to process that destroy, not the territory ID of the unit!

I fixed this.

And I added a bit of preemptive guard code to partially handle this for disbands. But actually, now that I think about it, we need to properly test both retreats and disbands of units on special coasts. Because if webdip also expects you to specify the retreat and/or disband in terms of the province ID, i.e. the root territory ID, then we need a few further code changes beyond these pre-emptive guards. So let's test this.
 