### PR TITLE
Fix bugs

### DIFF
--- a/api.php
+++ b/api.php
@@ -912,6 +912,8 @@ class SetOrders extends ApiEntry {
 			if (empty($updatedOrders))
 				break;
 			// Load updated orders.
+			// FIXME this function (board/orders/orderinterface.php) may report an error
+			// via libHTML::notice, which is not friendly to JSON API.
 			$orderInterface->load();
 			$orderInterface->set(json_encode(array_values($updatedOrders)));
 			$results = $orderInterface->validate();

--- a/beta-src/src/components/controllers/WDMainController.tsx
+++ b/beta-src/src/components/controllers/WDMainController.tsx
@@ -27,9 +27,9 @@ const WDMainController: React.FC = function ({ children }): React.ReactElement {
 
   const { countryID } = overview.user.member;
 
-  const overviewKey = getPhaseKey(overview);
-  const statusKey = getPhaseKey(status);
-  const dataKey = getPhaseKey(data.contextVars?.context);
+  const overviewKey = getPhaseKey(overview, "<BAD OVERVIEW_KEY>");
+  const statusKey = getPhaseKey(status, "<BAD STATUS_KEY>");
+  const dataKey = getPhaseKey(data.contextVars?.context, "<BAD DATA_KEY>");
 
   const dispatchFetchOverview = () => {
     const { game } = store.getState();

--- a/beta-src/src/components/controllers/WDMainController.tsx
+++ b/beta-src/src/components/controllers/WDMainController.tsx
@@ -29,9 +29,7 @@ const WDMainController: React.FC = function ({ children }): React.ReactElement {
 
   const overviewKey = getPhaseKey(overview);
   const statusKey = getPhaseKey(status);
-  const dataKey = data.contextVars
-    ? getPhaseKey(data.contextVars.context)
-    : "<BAD>";
+  const dataKey = getPhaseKey(data.contextVars?.context);
 
   const dispatchFetchOverview = () => {
     const { game } = store.getState();

--- a/beta-src/src/components/map/components/WDProvinceOverlay.tsx
+++ b/beta-src/src/components/map/components/WDProvinceOverlay.tsx
@@ -105,6 +105,17 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
       y={provinceMapData.y}
       overflow="visible"
     >
+      {highlightChoice && (
+        <path
+          d={provinceMapData.path}
+          fill="none"
+          fillOpacity={0.0}
+          id={`${province}-choice-outline`}
+          stroke="black"
+          strokeOpacity={1}
+          strokeWidth={5}
+        />
+      )}
       {provinceMapData.unitSlots
         .filter(({ name }) => name in unitFCs)
         .map(({ name, x, y }) => (
@@ -129,17 +140,6 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
             </WDUnitSlot>
           );
         })}
-      {highlightChoice && (
-        <path
-          d={provinceMapData.path}
-          fill="none"
-          fillOpacity={0.0}
-          id={`${province}-choice-outline`}
-          stroke="black"
-          strokeOpacity={1}
-          strokeWidth={5}
-        />
-      )}
     </svg>
   );
 };

--- a/beta-src/src/components/ui/WDMoveControls.tsx
+++ b/beta-src/src/components/ui/WDMoveControls.tsx
@@ -69,6 +69,11 @@ const WDMoveControls: React.FC = function (): React.ReactElement {
 
   const clickButton = (type: Move) => {
     console.log("Entered save button click");
+    // When you click save or ready, it should clear any actively entered order you have going,
+    // and/or any of the move input flyover. It doesn't make sense to ready and have the UI
+    // stay with a partially-entered order.
+    dispatch(gameApiSliceActions.resetOrder());
+
     if ("currentOrders" in data && "contextVars" in data) {
       const { currentOrders, contextVars } = data;
       if (contextVars && currentOrders) {

--- a/beta-src/src/interfaces/state/SavedOrdersConfirmation.ts
+++ b/beta-src/src/interfaces/state/SavedOrdersConfirmation.ts
@@ -5,8 +5,8 @@ export default interface SavedOrdersConfirmation {
   invalid: boolean;
   notice: string;
   orders: SavedOrder;
-  statusIcon: string;
-  statusText: string;
+  // statusIcon: string;
+  // statusText: string;
   newContext?: ContextVar["context"];
   newContextKey?: ContextVar["contextKey"];
 }

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -140,10 +140,23 @@ export const saveOrders = createAsyncThunk(
     formData.set("contextKey", data.contextKey);
     const response = await submitOrders(formData, data.queryParams);
     console.log({ response });
-    const confirmation: string = response.headers["x-json"] || "";
-    const parsed: SavedOrdersConfirmation = JSON.parse(
-      confirmation.substring(1, confirmation.length - 1),
-    );
+    // Sometimes webdip sends back a response that doesn't have the "x-json" header at all,
+    // instead it has an HTML page displaying an error message.
+    // We're of course not going to try to render a whole HTML page, so instead we simply
+    // manually construct an error message.
+    const confirmation: string = response.headers["x-json"];
+    let parsed: SavedOrdersConfirmation;
+    if (!confirmation) {
+      parsed = {
+        invalid: true,
+        notice: "Error saving orders, no server response or game already advanced to next phase",
+        orders: {},
+      };
+    } else {
+      parsed = JSON.parse(
+        confirmation.substring(1, confirmation.length - 1),
+      );
+    }
     return parsed;
   },
 );

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -149,13 +149,12 @@ export const saveOrders = createAsyncThunk(
     if (!confirmation) {
       parsed = {
         invalid: true,
-        notice: "Error saving orders, no server response or game already advanced to next phase",
+        notice:
+          "Error saving orders, no server response or game already advanced to next phase",
         orders: {},
       };
     } else {
-      parsed = JSON.parse(
-        confirmation.substring(1, confirmation.length - 1),
-      );
+      parsed = JSON.parse(confirmation.substring(1, confirmation.length - 1));
     }
     return parsed;
   },

--- a/beta-src/src/state/interfaces/SavedOrders.ts
+++ b/beta-src/src/state/interfaces/SavedOrders.ts
@@ -18,7 +18,7 @@ export interface OrderMeta extends SharedMeta {
 }
 
 export interface EditOrder extends SharedMeta {
-  saved?: boolean;
+  saved: boolean;
 }
 
 export interface EditOrderMeta {

--- a/beta-src/src/utils/map/getOrdersMeta.ts
+++ b/beta-src/src/utils/map/getOrdersMeta.ts
@@ -10,17 +10,17 @@ interface Props {
 export default function getOrdersMeta(
   data: GameDataResponse["data"],
   phase: GameState["overview"]["phase"],
-): Props {
+): EditOrderMeta {
   const { contextVars, currentOrders, units } = data;
 
-  const updateOrdersMeta = {};
+  const updateOrdersMeta: EditOrderMeta = {};
   if (contextVars?.context && currentOrders?.length) {
     if (phase === "Builds") {
       currentOrders?.forEach(({ id, toTerrID, type }) => {
         updateOrdersMeta[id] = {
           saved: true,
           update: {
-            type: toTerrID ? type : "Wait",
+            type: toTerrID ? type || "" : "Wait",
             toTerrID,
           },
         };
@@ -30,24 +30,16 @@ export default function getOrdersMeta(
 
       currentOrders.forEach((o) => {
         const { id, unitID, type, toTerrID, fromTerrID, viaConvoy } = o;
-        if (units[unitID]) {
+        if (units[unitID]?.id) {
           newOrders.push([o, units[unitID]]);
           updateOrdersMeta[id] = {
+            saved: true,
             update: {
-              type,
+              type: type || "",
               toTerrID,
               fromTerrID,
               viaConvoy,
             },
-          };
-        }
-      });
-
-      newOrders.forEach(([orderData, orderUnit]) => {
-        if (units[orderUnit.id]) {
-          updateOrdersMeta[orderData.id] = {
-            ...{ saved: true },
-            ...updateOrdersMeta[orderData.id],
           };
         }
       });

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -17,8 +17,14 @@ import { getLegalOrders } from "./precomputeLegalOrders";
 export default function fetchGameDataFulfilled(state: GameState, action): void {
   state.apiStatus = "succeeded";
 
-  const oldPhaseKey = getPhaseKey(state.data.data.contextVars?.context);
-  const newPhaseKey = getPhaseKey(action.payload.data.contextVars?.context);
+  const oldPhaseKey = getPhaseKey(
+    state.data.data.contextVars?.context,
+    "<BAD OLD_DATA_KEY>",
+  );
+  const newPhaseKey = getPhaseKey(
+    action.payload.data.contextVars?.context,
+    "<BAD NEW_DATA_KEY>",
+  );
   console.log(`fetchGameDataFulfilled  ${oldPhaseKey} -> ${newPhaseKey}`);
 
   // Upon phase change, sweep away all orders from the previous turn

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -38,8 +38,10 @@ export default function fetchGameDataFulfilled(state: GameState, action): void {
     (acc, meta) => acc + 1 - +meta.saved,
     0,
   );
-  if (!numUnsavedOrders) {
-    console.log("Updating ordersMeta");
+  // If all orders are saved, then update them from queries.
+  // If not all orders are saved, then we want to keep the current UI state rather than
+  // grabbing the new orders from the server.
+  if (numUnsavedOrders === 0) {
     updateOrdersMeta(state, getOrdersMeta(data, phase));
   }
 }

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -9,12 +9,23 @@ import getTerritoriesMeta from "../../../../getTerritoriesMeta";
 import getOrdersMeta from "../../../../map/getOrdersMeta";
 import { getUnitsLive } from "../../../../map/getUnits";
 import generateMaps from "../../../generateMaps";
+import getPhaseKey from "../../../getPhaseKey";
 import updateOrdersMeta from "../../../updateOrdersMeta";
 import { getLegalOrders } from "./precomputeLegalOrders";
 
 /* eslint-disable no-param-reassign */
 export default function fetchGameDataFulfilled(state: GameState, action): void {
   state.apiStatus = "succeeded";
+
+  const oldPhaseKey = getPhaseKey(state.data.data.contextVars?.context);
+  const newPhaseKey = getPhaseKey(action.payload.data.contextVars?.context);
+  console.log(`fetchGameDataFulfilled  ${oldPhaseKey} -> ${newPhaseKey}`);
+
+  // Upon phase change, sweep away all orders from the previous turn
+  if (oldPhaseKey !== newPhaseKey) {
+    state.ordersMeta = {};
+  }
+
   state.data = action.payload;
   const currentState = current(state);
   const {

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameOverview/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameOverview/fulfilled.ts
@@ -11,8 +11,8 @@ export default function fetchGameOverviewFulfilled(
   state.outstandingOverviewRequests = false;
   const response: GameOverviewResponse = action.payload;
 
-  const oldPhaseKey = getPhaseKey(state.overview);
-  const newPhaseKey = getPhaseKey(response);
+  const oldPhaseKey = getPhaseKey(state.overview, "<BAD OLD_OVERVIEW_KEY>");
+  const newPhaseKey = getPhaseKey(response, "<BAD NEW_OVERVIEW_KEY>");
   console.log({ oldPhaseKey, newPhaseKey });
   if (oldPhaseKey !== newPhaseKey) {
     state.needsGameData = true;

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled.ts
@@ -1,15 +1,7 @@
 import { current } from "@reduxjs/toolkit";
-import TerritoryMap from "../../../../../data/map/variants/classic/TerritoryMap";
-import Territory from "../../../../../enums/map/variants/classic/Territory";
 import GameDataResponse from "../../../../../state/interfaces/GameDataResponse";
 import GameOverviewResponse from "../../../../../state/interfaces/GameOverviewResponse";
 import { GameState } from "../../../../../state/interfaces/GameState";
-import UnitType from "../../../../../types/UnitType";
-import getTerritoriesMeta from "../../../../getTerritoriesMeta";
-import getOrdersMeta from "../../../../map/getOrdersMeta";
-import { getUnitsLive } from "../../../../map/getUnits";
-import generateMaps from "../../../generateMaps";
-import updateOrdersMeta from "../../../updateOrdersMeta";
 
 /* eslint-disable no-param-reassign */
 export default function fetchGameStatusFulfilled(

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
@@ -6,8 +6,13 @@ import getOrderStates from "../../../getOrderStates";
 export default function saveOrdersFulfilled(state, action): void {
   console.log("saveOrders fulfilled");
   if (action.payload) {
-    const { invalid, notice, orders, newContext, newContextKey }: SavedOrdersConfirmation =
-      action.payload;
+    const {
+      invalid,
+      notice,
+      orders,
+      newContext,
+      newContextKey,
+    }: SavedOrdersConfirmation = action.payload;
     if (newContext && newContextKey) {
       state.data.data.contextVars = {
         context: newContext,
@@ -33,7 +38,10 @@ export default function saveOrdersFulfilled(state, action): void {
       if (notice) {
         setAlert(state.alert, `Error saving orders: ${notice}`);
       } else {
-        setAlert(state.alert, `Unknown error saving orders, server indicated that API call was invalid`);
+        setAlert(
+          state.alert,
+          `Unknown error saving orders, server indicated that API call was invalid`,
+        );
       }
     }
   }

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
@@ -1,11 +1,12 @@
 import SavedOrdersConfirmation from "../../../../../interfaces/state/SavedOrdersConfirmation";
+import { setAlert } from "../../../../../state/interfaces/GameAlert";
 import getOrderStates from "../../../getOrderStates";
 
 /* eslint-disable no-param-reassign */
 export default function saveOrdersFulfilled(state, action): void {
   console.log("saveOrders fulfilled");
   if (action.payload) {
-    const { orders, newContext, newContextKey }: SavedOrdersConfirmation =
+    const { invalid, notice, orders, newContext, newContextKey }: SavedOrdersConfirmation =
       action.payload;
     if (newContext && newContextKey) {
       state.data.data.contextVars = {
@@ -26,5 +27,14 @@ export default function saveOrdersFulfilled(state, action): void {
         state.ordersMeta[id].saved = true;
       }
     });
+
+    // Report any errors
+    if (invalid) {
+      if (notice) {
+        setAlert(state.alert, `Error saving orders: ${notice}`);
+      } else {
+        setAlert(state.alert, `Unknown error saving orders, server indicated that API call was invalid`);
+      }
+    }
   }
 }

--- a/beta-src/src/utils/state/getPhaseKey.ts
+++ b/beta-src/src/utils/state/getPhaseKey.ts
@@ -3,8 +3,11 @@ import GameStatusResponse from "../../state/interfaces/GameStatusResponse";
 import { IContext } from "../../models/Interfaces";
 
 const getPhaseKey = function (
-  data: GameOverviewResponse | GameStatusResponse | IContext,
+  data: GameOverviewResponse | GameStatusResponse | IContext | undefined,
 ): string {
+  if (!data) {
+    return "<BAD>";
+  }
   return `${data.turn}.${data.phase}`;
 };
 

--- a/beta-src/src/utils/state/getPhaseKey.ts
+++ b/beta-src/src/utils/state/getPhaseKey.ts
@@ -4,9 +4,10 @@ import { IContext } from "../../models/Interfaces";
 
 const getPhaseKey = function (
   data: GameOverviewResponse | GameStatusResponse | IContext | undefined,
+  valueIfUndefined: string,
 ): string {
   if (!data) {
-    return "<BAD>";
+    return valueIfUndefined;
   }
   return `${data.turn}.${data.phase}`;
 };


### PR DESCRIPTION
This fixes 3 bugs:

* The one that a few people noticed in the test today, which is that builds don't register properly after you play for a while. The reason is indeed that orderMeta gets filled up with crufty old orders, and then our code when it tries to find the orders involving particular territories, it erroneously finds cruft instead of the actual orders this phase. So to fix it, now we clear the ordersMeta whenever the GameData updates.

* If you try to ready your orders, then unready them and do stuff in the UI while the server has already moved on to next phase (presumably also if you try to save your orders, then do stuff and save again but the time limit for the phase has passed) then when you try to save, the server will send you back an HTML page (NOT a json response!) in response to your API query. This causes us to crash. So we add some code in the order saving handler to deal with this and instead report an error message to the user.

* If you partially input an order, and then ready while you have a partial order, it locks your UI into a state where you have that partial order but aren't allowed to complete it. This doesn't make much sense to have a partial order while readied anyways, so now when you save or ready it clears any partial order you have.

Also we rearrange the drawing to make it so that it is less common for an overlay border to draw on top of a unit.

And we mildly polish up some types and fix up where the typechecker resultingly complained, and simplify a bit of complexity in getOrdersMeta.