### PR TITLE
Make save button glow when orders are not saved yet

### DIFF
--- a/beta-src/src/components/ui/WDButton.tsx
+++ b/beta-src/src/components/ui/WDButton.tsx
@@ -31,23 +31,23 @@ const WDButton: React.FC<WDButtonProps> = function ({
       variant="contained"
       style={{
         animation:
-          doAnimateGlow && !disabled ? "glowing 1.5s linear infinite" : "",
+          doAnimateGlow && !disabled ? "glowing 1.5s ease infinite" : "",
       }}
     >
       <style>
         {`
         @keyframes glowing {
           0% {
-            background-color: #000000;
-            box-shadow: 0 0 5px #000000;
-          }
-          50% {
             background-color: #447733;
             box-shadow: 0 0 15px #447733;
           }
-          100% {
+          50% {
             background-color: #000000;
             box-shadow: 0 0 5px #000000;
+          }
+          100% {
+            background-color: #447733;
+            box-shadow: 0 0 15px #447733;
           }
         }`}
       </style>

--- a/beta-src/src/components/ui/WDButton.tsx
+++ b/beta-src/src/components/ui/WDButton.tsx
@@ -9,6 +9,7 @@ interface WDButtonProps {
   onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
   startIcon?: React.ReactNode | undefined;
   sx?: SxProps | undefined;
+  doAnimateGlow?: boolean;
 }
 
 const WDButton: React.FC<WDButtonProps> = function ({
@@ -17,6 +18,7 @@ const WDButton: React.FC<WDButtonProps> = function ({
   disabled,
   onClick,
   startIcon,
+  doAnimateGlow,
   sx,
 }): React.ReactElement {
   return (
@@ -27,7 +29,28 @@ const WDButton: React.FC<WDButtonProps> = function ({
       onClick={onClick}
       startIcon={startIcon}
       variant="contained"
+      style={{
+        animation:
+          doAnimateGlow && !disabled ? "glowing 1.5s linear infinite" : "",
+      }}
     >
+      <style>
+        {`
+        @keyframes glowing {
+          0% {
+            background-color: #000000;
+            box-shadow: 0 0 5px #000000;
+          }
+          50% {
+            background-color: #447733;
+            box-shadow: 0 0 15px #447733;
+          }
+          100% {
+            background-color: #000000;
+            box-shadow: 0 0 5px #000000;
+          }
+        }`}
+      </style>
       {children}
     </Button>
   );
@@ -39,6 +62,7 @@ WDButton.defaultProps = {
   onClick: undefined,
   startIcon: undefined,
   sx: undefined,
+  doAnimateGlow: false,
 };
 
 export default WDButton;

--- a/beta-src/src/components/ui/WDMoveControls.tsx
+++ b/beta-src/src/components/ui/WDMoveControls.tsx
@@ -15,12 +15,16 @@ import {
 } from "../../state/game/game-api-slice";
 import UpdateOrder from "../../interfaces/state/UpdateOrder";
 import MoveStatus from "../../types/MoveStatus";
+import { RootState } from "../../state/store";
 
 const WDMoveControls: React.FC = function (): React.ReactElement {
   const theme = useTheme();
   const [viewport] = useViewport();
   const { data } = useAppSelector(gameData);
   const ordersMeta = useAppSelector(gameOrdersMeta);
+  const currentOrderInProgress = useAppSelector(
+    ({ game: { order } }: RootState) => order.inProgress,
+  );
   const [readyDisabled, setReadyDisabled] = React.useState(false);
   const [gameState, setGameState] = React.useState<MoveStatus>({
     save: false,
@@ -128,6 +132,8 @@ const WDMoveControls: React.FC = function (): React.ReactElement {
   }
 
   const saveDisabled = gameState.ready || !gameState.save;
+  const doAnimateGlow =
+    !saveDisabled && ordersLength !== ordersSaved && !currentOrderInProgress;
 
   return (
     <Stack
@@ -144,6 +150,7 @@ const WDMoveControls: React.FC = function (): React.ReactElement {
             ? undefined
             : theme.palette.svg.filters.dropShadows[0],
         }}
+        doAnimateGlow={doAnimateGlow}
       >
         Save
       </WDButton>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11942395/171518051-5619bb72-36f9-4be2-996a-7ab256affcc3.png)

The save button pulses from black to green while you have a completed unsaved order entered. It's animated with a period of 1.5s, so the screenshot doesn't quite capture it.

What do you think? Too distracting? Or just right?