### PR TITLE
Big units

### DIFF
--- a/beta-src/src/components/controllers/WDUnitController.tsx
+++ b/beta-src/src/components/controllers/WDUnitController.tsx
@@ -3,22 +3,52 @@ import { GameIconProps } from "../../interfaces/Icons";
 import debounce from "../../utils/debounce";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
 import { gameApiSliceActions } from "../../state/game/game-api-slice";
-import WDFleetIcon from "../ui/units/WDFleetIcon";
-import WDArmyIcon from "../ui/units/WDArmyIcon";
+import WDFleetIcon, {
+  FLEET_RAW_ICON_WIDTH,
+  FLEET_RAW_ICON_HEIGHT,
+} from "../ui/units/WDFleetIcon";
+import WDArmyIcon, {
+  ARMY_RAW_ICON_WIDTH,
+  ARMY_RAW_ICON_HEIGHT,
+} from "../ui/units/WDArmyIcon";
 
 interface UnitControllerProps {
   meta: GameIconProps["meta"];
   type: GameIconProps["type"];
   iconState: GameIconProps["iconState"];
+  unitWidth: number;
+  unitHeight: number;
 }
 
 const WDUnitController: React.FC<UnitControllerProps> = function ({
   meta,
   type,
   iconState,
+  unitWidth,
+  unitHeight,
 }): React.ReactElement {
+  const iconWidth =
+    type === "Fleet" ? FLEET_RAW_ICON_WIDTH : ARMY_RAW_ICON_WIDTH;
+  const iconHeight =
+    type === "Fleet" ? FLEET_RAW_ICON_HEIGHT : ARMY_RAW_ICON_HEIGHT;
+
+  // The icons expect that 0,0 is the upper left corner of the unit, whereas this WDUnitController
+  // svg element is expected to be positioned such that 0,0 is the center of the
+  // unit. So we need to translate to reconcile these.
+  const xOffset = iconWidth / 2;
+  const yOffset = iconHeight / 2;
+
+  // Translate from the coordinate scale of the icons in WDFleetIcon and
+  // WDArmyIcon to the size we want to actually draw this unit
+  const xScale = unitWidth / iconWidth;
+  const yScale = unitHeight / iconHeight;
+
+  const transform = `scale(${xScale}, ${yScale}) translate(-${xOffset},-${yOffset})`;
   return (
-    <g style={{ pointerEvents: "none" }}>
+    <g
+      style={{ pointerEvents: "none", overflow: "visible" }}
+      transform={transform}
+    >
       {type === "Fleet" && (
         <WDFleetIcon iconState={iconState} country={meta.country} />
       )}

--- a/beta-src/src/components/map/components/WDArrowContainer.tsx
+++ b/beta-src/src/components/map/components/WDArrowContainer.tsx
@@ -121,7 +121,7 @@ function accumulateSupportHoldOrderArrows(
       // doesn't overlap with it.
       const hasMutualSupport =
         supporterProvIDToSupporteeProvID[supporteeProvID] === supporterProvID;
-      const offsetArrowSourcePixels = hasMutualSupport ? 4.5 : 0;
+      const offsetArrowSourcePixels = hasMutualSupport ? 6 : 0;
       console.log({
         supporteeProvID,
         supporterProvID,
@@ -362,12 +362,12 @@ function accumulateBuildCircles(
       arrows.push(
         <circle
           key={`build-circle-${terr}`}
-          cx={x + w / 2}
-          cy={y + h / 2}
-          r={10 + (w + h) / 4}
+          cx={x}
+          cy={y}
+          r={(1.4 * (w + h)) / 4}
           fill="none"
           stroke="rgb(0,150,0)"
-          strokeWidth={6}
+          strokeWidth={0.05 * (w + h)}
         />,
       );
     });

--- a/beta-src/src/components/map/components/WDBuildUnitButtons.tsx
+++ b/beta-src/src/components/map/components/WDBuildUnitButtons.tsx
@@ -7,7 +7,6 @@ import Province from "../../../enums/map/variants/classic/Province";
 import UIState from "../../../enums/UIState";
 import WDArmyIcon from "../../ui/units/WDArmyIcon";
 import WDFleetIcon from "../../ui/units/WDFleetIcon";
-import { UNIT_WIDTH, UNIT_HEIGHT } from "../../ui/units/WDUnit";
 
 export interface BuildData {
   availableOrder: string;
@@ -34,13 +33,9 @@ const WDBuildUnitButtons: React.FC<BuildData> = function ({
 }): React.ReactElement {
   const provinceMapData = provincesMapData[province];
   let svgX =
-    provinceMapData.x +
-    provinceMapData.unitSlotsBySlotName[unitSlotName].x +
-    UNIT_WIDTH / 2;
+    provinceMapData.x + provinceMapData.unitSlotsBySlotName[unitSlotName].x;
   let svgY =
-    provinceMapData.y +
-    provinceMapData.unitSlotsBySlotName[unitSlotName].y +
-    UNIT_HEIGHT / 2;
+    provinceMapData.y + provinceMapData.unitSlotsBySlotName[unitSlotName].y;
 
   let rw = 70;
   const rh = 70;

--- a/beta-src/src/components/map/components/WDFlyoutButton.tsx
+++ b/beta-src/src/components/map/components/WDFlyoutButton.tsx
@@ -9,7 +9,6 @@ import { useAppDispatch, useAppSelector } from "../../../state/hooks";
 import WDBuildUnitButtons from "./WDBuildUnitButtons";
 import Province from "../../../enums/map/variants/classic/Province";
 import provincesMapData from "../../../data/map/ProvincesMapData";
-import { UNIT_HEIGHT, UNIT_WIDTH } from "../../ui/units/WDUnit";
 
 type Position = "left" | "right" | "top" | "bottom";
 
@@ -34,13 +33,9 @@ const WDFlyoutButton: React.FC<WDOrderTypeButtonProps> = function ({
     return <Box />;
 
   const unitX =
-    provinceMapData.x +
-    provinceMapData.unitSlotsBySlotName[unitSlotName].x +
-    UNIT_WIDTH / 2;
+    provinceMapData.x + provinceMapData.unitSlotsBySlotName[unitSlotName].x;
   const unitY =
-    provinceMapData.y +
-    provinceMapData.unitSlotsBySlotName[unitSlotName].y +
-    UNIT_HEIGHT / 2;
+    provinceMapData.y + provinceMapData.unitSlotsBySlotName[unitSlotName].y;
 
   const fontSize = 24;
   const rw = 55 + fontSize * text.length * 0.4;

--- a/beta-src/src/components/map/components/WDProvinceOverlay.tsx
+++ b/beta-src/src/components/map/components/WDProvinceOverlay.tsx
@@ -1,32 +1,14 @@
 import { useTheme } from "@mui/material";
 import * as React from "react";
-import countryMap from "../../../data/map/variants/classic/CountryMap";
-import TerritoryMap, {
-  territoryToWebdipName,
-} from "../../../data/map/variants/classic/TerritoryMap";
 import UIState from "../../../enums/UIState";
 import { Coordinates, ProvinceMapData } from "../../../interfaces";
-import {
-  gameApiSliceActions,
-  gameMaps,
-  gameOrder,
-  gameOrdersMeta,
-  gameOverview,
-  gameTerritoriesMeta,
-} from "../../../state/game/game-api-slice";
-import { useAppDispatch, useAppSelector } from "../../../state/hooks";
-import { TerritoryMeta } from "../../../state/interfaces/TerritoriesState";
-import ClickObjectType from "../../../types/state/ClickObjectType";
 import OrderType from "../../../types/state/OrderType";
 import UnitType from "../../../types/UnitType";
-import WDUnit, { UNIT_HEIGHT, UNIT_WIDTH } from "../../ui/units/WDUnit";
-import WDCenter from "./WDCenter";
-import WDLabel from "./WDLabel";
+import WDUnit from "../../ui/units/WDUnit";
 import WDUnitSlot from "./WDUnitSlot";
 import { Unit, UnitDrawMode } from "../../../utils/map/getUnits";
 import Province from "../../../enums/map/variants/classic/Province";
 import Territory from "../../../enums/map/variants/classic/Territory";
-import OrdersMeta from "../../../state/interfaces/SavedOrders";
 import { IProvinceStatus } from "../../../models/Interfaces";
 
 interface WDProvinceOverlayProps {
@@ -64,7 +46,10 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
           unitState = UIState.HOLD;
           break;
         case UnitDrawMode.BUILD:
-          unitState = UIState.BUILD;
+          // This state of drawing the unit reduces constrast on the unit and isn't necessary
+          // now that we have green build circles highlighting the new builds.
+          // unitState = UIState.BUILD;
+          unitState = UIState.NONE;
           break;
         case UnitDrawMode.DISLODGING:
           unitState = UIState.NONE;
@@ -122,8 +107,8 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
             <WDUnitSlot
               key={unitName}
               name={unitName}
-              x={arrowReceiver.x - UNIT_WIDTH / 2}
-              y={arrowReceiver.y - UNIT_HEIGHT / 2}
+              x={arrowReceiver.x}
+              y={arrowReceiver.y}
             >
               {unitFCsDislodging[name]}
             </WDUnitSlot>

--- a/beta-src/src/components/map/components/WDUnitSlot.tsx
+++ b/beta-src/src/components/map/components/WDUnitSlot.tsx
@@ -13,7 +13,13 @@ const WDUnitSlot: React.FC<WDUnitSlotProps> = function ({
   y,
 }): React.ReactElement {
   return (
-    <svg className="unit-slot" id={`${name}-unit-slot`} x={x} y={y}>
+    <svg
+      className="unit-slot"
+      id={`${name}-unit-slot`}
+      style={{ overflow: "visible" }}
+      x={x}
+      y={y}
+    >
       {children}
     </svg>
   );

--- a/beta-src/src/components/ui/WDBuildCounts.tsx
+++ b/beta-src/src/components/ui/WDBuildCounts.tsx
@@ -11,7 +11,7 @@ import { useAppSelector } from "../../state/hooks";
 import WDArmyIcon from "./units/WDArmyIcon";
 import UIState from "../../enums/UIState";
 import Country from "../../enums/Country";
-import { UNIT_HEIGHT } from "./units/WDUnit";
+import { UNIT_HEIGHT, UNIT_WIDTH } from "./units/WDUnit";
 
 const range = (N: number) => Array.from(Array(N).keys());
 
@@ -45,7 +45,11 @@ const WDBuildCounts: React.FC = function (): React.ReactElement {
         {range(numRemainingBuilds).map((buildIdx) => (
           <svg
             key={buildIdx}
-            style={{ height: UNIT_HEIGHT, width: UNIT_WIDTH_SQUOOSHED }}
+            style={{
+              height: UNIT_HEIGHT,
+              width: UNIT_WIDTH_SQUOOSHED,
+              overflow: "visible",
+            }}
           >
             <WDArmyIcon country={Country.FRANCE} iconState={UIState.BUILD} />
           </svg>
@@ -53,7 +57,11 @@ const WDBuildCounts: React.FC = function (): React.ReactElement {
         {range(numRemainingDestroys).map((buildIdx) => (
           <svg
             key={buildIdx}
-            style={{ height: UNIT_HEIGHT, width: UNIT_WIDTH_SQUOOSHED }}
+            style={{
+              height: UNIT_HEIGHT,
+              width: UNIT_WIDTH_SQUOOSHED,
+              overflow: "visible",
+            }}
           >
             <WDArmyIcon country={Country.FRANCE} iconState={UIState.DESTROY} />
           </svg>

--- a/beta-src/src/components/ui/units/WDArmyIcon.tsx
+++ b/beta-src/src/components/ui/units/WDArmyIcon.tsx
@@ -3,6 +3,12 @@ import { useTheme } from "@mui/material/styles";
 import UIState from "../../../enums/UIState";
 import { IconProps } from "../../../interfaces/Icons";
 
+// The drawing of this icon assumes a coordinate system where the icon fits within
+// a rectangle from [0,0] to [ARMY_RAW_ICON_WIDTH,ARMY_RAW_ICON_HEIGHT]
+// This gets scaled a bit by WDUnitController
+export const ARMY_RAW_ICON_WIDTH = 50;
+export const ARMY_RAW_ICON_HEIGHT = 50;
+
 const WDArmyIcon: React.FC<IconProps> = function ({
   country,
   iconState = UIState.NONE,

--- a/beta-src/src/components/ui/units/WDFleetIcon.tsx
+++ b/beta-src/src/components/ui/units/WDFleetIcon.tsx
@@ -3,6 +3,12 @@ import { useTheme } from "@mui/material/styles";
 import { IconProps } from "../../../interfaces/Icons";
 import UIState from "../../../enums/UIState";
 
+// The drawing of this icon assumes a coordinate system where the icon fits within
+// a rectangle from [0,0] to [FLEET_RAW_ICON_WIDTH,FLEET_RAW_ICON_HEIGHT]
+// This gets scaled a bit by WDUnitController
+export const FLEET_RAW_ICON_WIDTH = 50;
+export const FLEET_RAW_ICON_HEIGHT = 50;
+
 const WDFleetIcon: React.FC<IconProps> = function ({
   country,
   iconState = UIState.NONE,

--- a/beta-src/src/components/ui/units/WDUnit.tsx
+++ b/beta-src/src/components/ui/units/WDUnit.tsx
@@ -6,8 +6,8 @@ import { GameIconProps } from "../../../interfaces/Icons";
 import WDArmyIcon from "./WDArmyIcon";
 import { useAppSelector } from "../../../state/hooks";
 
-export const UNIT_HEIGHT = 50;
-export const UNIT_WIDTH = 50;
+export const UNIT_HEIGHT = 75;
+export const UNIT_WIDTH = 75;
 
 const WDUnit: React.FC<GameIconProps> = function ({
   id = undefined,
@@ -24,8 +24,15 @@ const WDUnit: React.FC<GameIconProps> = function ({
       id={id}
       width={UNIT_WIDTH}
       viewBox={viewBox}
+      style={{ overflow: "visible" }}
     >
-      <WDUnitController meta={meta} type={type} iconState={iconState} />
+      <WDUnitController
+        meta={meta}
+        type={type}
+        iconState={iconState}
+        unitWidth={UNIT_WIDTH}
+        unitHeight={UNIT_HEIGHT}
+      />
     </svg>
   );
 };

--- a/beta-src/src/data/map/ProvincesMapData.ts
+++ b/beta-src/src/data/map/ProvincesMapData.ts
@@ -3139,10 +3139,20 @@ const provincesMapData: { [key: string]: ProvinceMapData } = Object.fromEntries(
         }
         territory = preUnitSlot.territory;
       }
+      // When all the coordinates above were developed, they were assuming the
+      // unit would be 50x50 and the coordinates were specifying the upper left
+      // corner of that unit.
+
+      // The units aren't actually 50x50 any more, and the rest of the UI
+      // is written to assume the coordinates of a unit give the location of the
+      // center of the unit. So we need as a preprocessing step to subtract
+      // 25 from all the coordinates above.
+      const UNIT_OFFSET = 25;
+
       const unitSlot: UnitSlot = {
         name: preUnitSlot.name,
-        x: preUnitSlot.x,
-        y: preUnitSlot.y,
+        x: preUnitSlot.x + UNIT_OFFSET,
+        y: preUnitSlot.y + UNIT_OFFSET,
         territory,
         arrowReceiver: preUnitSlot.arrowReceiver,
       };

--- a/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
+++ b/beta-src/src/utils/map/WDArrowMarkerDefs.tsx
@@ -42,13 +42,15 @@ const WDArrowMarkerColors = function (
               <marker
                 id={`arrowHead__${ArrowType[arrowType]}_${ArrowColor[arrowColor]}`}
                 key={`arrowHead__${ArrowType[arrowType]}_${ArrowColor[arrowColor]}`}
-                markerWidth={30}
-                markerHeight={30}
-                refX={5}
-                refY={15}
+                markerWidth={90}
+                markerHeight={90}
+                refX={10}
+                refY={45}
                 orient="auto"
+                markerUnits="userSpaceOnUse"
+                strokeWidth={4}
               >
-                <path d=" M 8 22 A 10 10 180 0 1 8 8" stroke={config.main} />
+                <path d=" M 24 72 A 30 30 180 0 1 24 18" stroke={config.main} />
               </marker>
             ),
           )}

--- a/beta-src/src/utils/map/arrowDispatchReceiveCoordinates.ts
+++ b/beta-src/src/utils/map/arrowDispatchReceiveCoordinates.ts
@@ -3,32 +3,17 @@ export default function arrowDispatchReceiveCoordinates(
   unitW: number, // dispatch unit width
   rh: number, // receiver height
   rw: number, // receiver width
-  X1: number, // line x1
-  X2: number, // line x2
-  Y1: number, // line y1
-  Y2: number, // line y2
+  x1: number, // line x1
+  x2: number, // line x2
+  y1: number, // line y1
+  y2: number, // line y2
 ): {
   x1: number;
   x2: number;
   y1: number;
   y2: number;
 } {
-  let x1 = X1;
-  let x2 = X2;
-  let y1 = Y1;
-  let y2 = Y2;
-
-  // This function expects to receive the coordinates of the *upper left corners* of the
-  // dispatch and receiver, in the case when the dispatch and receiver have nonzero widths
-  // and heights.
-  // So the very first thing we need to do to compute a properly centered arrow is to center
-  // the coordinates.
-  x1 += unitW / 2;
-  y1 += unitH / 2;
-  x2 += rw / 2;
-  y2 += rh / 2;
-
-  // Next let's compute the angle that we need the arrow to go at
+  // Compute the angle that we need the arrow to go at
   // If there isn't an angle because the diff is too small, quit out immediately
   const xDiff = x2 - x1;
   const yDiff = y2 - y1;

--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -22,6 +22,7 @@ export function getTargetXYWH(
   let y;
   let width;
   let height;
+
   switch (type) {
     case "arrow": {
       // If the target of this arrow is itself an arrow, then target a point
@@ -72,8 +73,6 @@ export function getTargetXYWH(
       const toTerritoryData = TerritoryMap[toTerritoryName].provinceMapData;
       const { unitSlotName } = TerritoryMap[toTerritoryName];
 
-      x = toTerritoryData.x - UNIT_WIDTH / 2;
-      y = toTerritoryData.y - UNIT_HEIGHT / 2;
       if (toTerritoryData.unitSlotsBySlotName[unitSlotName]) {
         x += toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.x;
         y += toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.y;
@@ -98,12 +97,8 @@ export function getTargetXYWH(
       x = toTerritoryData.x;
       y = toTerritoryData.y;
       if (toTerritoryData.unitSlotsBySlotName[unitSlotName]) {
-        x +=
-          toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.x -
-          bufferSize / 2;
-        y +=
-          toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.y -
-          bufferSize / 2;
+        x += toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.x;
+        y += toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.y;
       }
       width = bufferSize;
       height = bufferSize;
@@ -122,7 +117,8 @@ export function getArrowX1Y1X2Y2(
   receiverIdentifier: Territory | [number, number, number, number],
 ): [number, number, number, number] {
   // Source of arrow
-  const [sx1, sy1, sourceWidth, sourceHeight] = getTargetXYWH(
+  // eslint-disable-next-line prefer-const
+  let [sx1, sy1, sourceWidth, sourceHeight] = getTargetXYWH(
     sourceType,
     sourceIdentifier,
   );
@@ -130,6 +126,15 @@ export function getArrowX1Y1X2Y2(
     receiverType,
     receiverIdentifier,
   );
+
+  // Draw the arrows slightly closer to a unit than their nominal size for the arrow source, the portion of
+  // the unit's nominal size that the unit icon actually covers is a bit smaller and
+  // the arrow looks a bit too far away otherwise.
+  const UNIT_SOURCE_SHRINK_FACTOR = 0.9;
+  if (sourceType === "unit" || sourceType === "dislodger") {
+    sourceWidth *= UNIT_SOURCE_SHRINK_FACTOR;
+    sourceHeight *= UNIT_SOURCE_SHRINK_FACTOR;
+  }
 
   const { x1, x2, y1, y2 } = arrowDispatchReceiveCoordinates(
     sourceHeight,
@@ -184,16 +189,16 @@ export default function drawArrowFunctional(
     case ArrowColor.RETREAT:
     case ArrowColor.SUPPORT_HOLD:
     case ArrowColor.SUPPORT_MOVE:
-      strokeWidth = 3;
+      strokeWidth = 3.5;
       break;
     case ArrowColor.MOVE_FAILED:
     case ArrowColor.CONVOY_FAILED:
     case ArrowColor.SUPPORT_HOLD_FAILED:
     case ArrowColor.SUPPORT_MOVE_FAILED:
-      strokeWidth = 2.5;
+      strokeWidth = 3;
       break;
     default:
-      strokeWidth = 3;
+      strokeWidth = 3.5;
   }
 
   if (offsetArrowSourcePixels > 0) {


### PR DESCRIPTION
Draw units bigger. And arrows mildly bolder. And fix coordinates for units to be the center of units, not the upper left corner, internally.

Before:
![image](https://user-images.githubusercontent.com/11942395/171688733-7dc8e8db-74f4-4f1b-865d-050372c16e87.png)


After
![image](https://user-images.githubusercontent.com/11942395/171688525-0f6c5f81-7d63-45e2-b709-54e3d155740f.png)
