### PR TITLE
hide order status when game is anonymous

### DIFF
--- a/api.php
+++ b/api.php
@@ -452,7 +452,6 @@ class GetGameMembers extends ApiEntry {
 				$votes = array_values($votes);
 			}
 		}
-
 		return [
 			'bet' => $member->bet,
 			'country' => $member->country,
@@ -461,12 +460,12 @@ class GetGameMembers extends ApiEntry {
 			'missedPhases' => $member->missedPhases,
 			'newMessagesFrom' => $retrievePrivateData ? $member->newMessagesFrom : [],
 			'online' => $member->online,
-			'orderStatus' => [
+			'orderStatus' => ($this->isAnon && !$retrievePrivateData ? ['Hidden' => 1] : [
 				'Ready' => $member->orderStatus->Ready,
 				'Saved' => $member->orderStatus->Saved,
 				'Completed' => $member->orderStatus->Completed,
 				'None' => $member->orderStatus->None,
-			],
+			]),
 			'status' => $member->status,
 			'supplyCenterNo' => $member->supplyCenterNo,
 			'timeLoggedIn' => $member->timeLoggedIn,

--- a/api/responses/game_state.php
+++ b/api/responses/game_state.php
@@ -255,7 +255,7 @@ class GameState {
 		global $DB;
 
 		// Loading game state
-		$gameRow = $DB->sql_hash("SELECT id, variantID, potType, turn, phase, gameOver, pressType, drawType, processTime, phaseMinutes FROM wD_Games WHERE id=".$this->gameID);
+		$gameRow = $DB->sql_hash("SELECT id, variantID, potType, turn, phase, gameOver, pressType, drawType, processTime, phaseMinutes, anon FROM wD_Games WHERE id=".$this->gameID);
 		if ( ! $gameRow )
 			throw new \Exception("Unknown game ID.");
 		$this->variantID = intval($gameRow['variantID']);
@@ -277,7 +277,7 @@ class GameState {
 		$this->orderStatuses = [];
 		while ($member = $DB->tabl_hash($orderStatusData)) {
 			$countryID = $member["countryID"];
-			$orderStatus = $member["orderStatus"];
+			$orderStatus = $gameRow['anon'] == 'Yes' ? 'Hidden' : $member["orderStatus"];
 			$this->orderStatuses[$countryID] = $orderStatus;
 		}	
 

--- a/beta-src/src/components/ui/WDCountryTable.tsx
+++ b/beta-src/src/components/ui/WDCountryTable.tsx
@@ -10,6 +10,7 @@ import {
   tableCellClasses,
   useTheme,
 } from "@mui/material";
+import { Lock } from "@mui/icons-material";
 import { styled } from "@mui/material/styles";
 import BetIcon from "./icons/country-table/WDBet";
 import CentersIcon from "./icons/country-table/WDCenters";
@@ -126,6 +127,9 @@ const WDCountryTable: React.FC<WDCountryTableProps> = function ({
                     case "orderStatus":
                       return (
                         <WDTableCell key={column.id} align={column.align}>
+                          {country.orderStatus.Hidden && (
+                            <Lock sx={{ fontSize: "16px", color: "#666" }} />
+                          )}
                           {(country.orderStatus.Saved ||
                             country.orderStatus.Ready) && (
                             <WDCheckmarkIcon

--- a/beta-src/src/interfaces/state/MemberData.ts
+++ b/beta-src/src/interfaces/state/MemberData.ts
@@ -5,6 +5,7 @@ export interface OrderStatus {
   None: boolean;
   Ready: boolean;
   Saved: boolean;
+  Hidden: boolean;
 }
 
 export interface MemberData {

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -74,6 +74,7 @@ const initialState: GameState = {
           None: false,
           Ready: false,
           Saved: false,
+          Hidden: false,
         },
         status: "Playing",
         supplyCenterNo: 4,


### PR DESCRIPTION
Hide the order status on the server side in anon games, and show a lock icon in the UI in that case.

![image](https://user-images.githubusercontent.com/5702157/171700366-8d5bc042-8a14-485a-bbfc-c7fbe58dd4d0.png)
