### PR TITLE
Make the map labels and various other text unhighlightable

### DIFF
--- a/beta-src/src/components/map/components/WDFlyoutButton.tsx
+++ b/beta-src/src/components/map/components/WDFlyoutButton.tsx
@@ -96,6 +96,9 @@ const WDFlyoutButton: React.FC<WDOrderTypeButtonProps> = function ({
           alignmentBaseline="middle"
           fontFamily="Roboto"
           fontSize={fontSize}
+          style={{
+            userSelect: "none",
+          }}
           fill="black"
         >
           {text}

--- a/beta-src/src/components/map/components/WDLabel.tsx
+++ b/beta-src/src/components/map/components/WDLabel.tsx
@@ -22,6 +22,7 @@ const WDLabel: React.FC<WDLabelProps> = function ({
         fill: theme.palette.primary.main,
         fontWeight: 900,
         fontSize: "150%",
+        userSelect: "none",
         ...style,
       }}
       x={x}

--- a/beta-src/src/components/ui/WDUI.tsx
+++ b/beta-src/src/components/ui/WDUI.tsx
@@ -201,6 +201,7 @@ const WDUI: React.FC = function (): React.ReactElement {
             borderRadius: 2,
             fontSize: "0.875rem",
             fontWeight: "700",
+            userSelect: "none",
           }}
           title={`Currently playing as ${user.member.country}`}
         >


### PR DESCRIPTION
The labels on the map can currently be selected/highlighted as text. 

They don't respond to the mouse by themselves, but if you click and drag starting from text that *is* highlightable (such as your message history) and then drag the mouse over the map without realizing that you've done so, the labels will highlight, and then the very fact that the clicking on map doesn't normally affect highlighting will stop you from unhighlighting the text, leading to confused user.

This CSS property should make them not highlightable even in this way.
