### PR TITLE
Filter self-intersectign convoys

### DIFF
--- a/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
+++ b/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
@@ -92,9 +92,11 @@ const WDBoardMap: React.FC<WDBoardMapProps> = function ({
             maps.terrIDToProvince[maps.unitToTerrID[curOrder.unitID]],
             maps.terrIDToProvince[curOrder.fromTerrID],
           ];
-          provincesToChoose = legalOrders.legalConvoysByUnitID[curOrder.unitID][
-            maps.terrIDToProvince[curOrder.fromTerrID]
-          ].map((convoy) => TerritoryMap[convoy.dest].province);
+          provincesToChoose = Object.keys(
+            legalOrders.legalConvoysByUnitID[curOrder.unitID][
+              maps.terrIDToProvince[curOrder.fromTerrID]
+            ],
+          ) as Province[];
         } else {
           provincesToHighlight = [
             maps.terrIDToProvince[maps.unitToTerrID[curOrder.unitID]],

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/precomputeLegalOrders.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/precomputeLegalOrders.ts
@@ -9,19 +9,22 @@ import GameOverviewResponse from "../../../../../state/interfaces/GameOverviewRe
 import { GameState } from "../../../../../state/interfaces/GameState";
 import GameStateMaps from "../../../../../state/interfaces/GameStateMaps";
 
+type UnitID = string;
+type ProvinceID = string;
+
 interface LegalVia {
   dest: Territory;
   // A list of all the possible paths in province IDs by which this VIA move
   // could be accomplished. Contains the starting location but not the ending
   // location, because that's the format a path needs to be in to be accepted
   // by the webdip API.
-  provIDPaths: string[][];
+  provIDPaths: ProvinceID[][];
 }
 
 interface LegalSupport {
   src: Province;
   dest: Province;
-  convoyProvIDPath: string[] | null;
+  convoyProvIDPath: ProvinceID[] | null;
 }
 
 interface LegalConvoy {
@@ -30,21 +33,24 @@ interface LegalConvoy {
   // Concatenate these two arrays if you want the final convoy path that you need
   // to give to webdip.
   // Do NOT modify these arrays.
-  provIDPath1: string[];
-  provIDPath2: string[];
+  provIDPath1: ProvinceID[];
+  provIDPath2: ProvinceID[];
 }
 
-type UnitID = string;
 export interface LegalOrders {
   legalMoveDestsByUnitID: { [key: UnitID]: Territory[] };
   legalRetreatDestsByUnitID: { [key: UnitID]: Territory[] };
   possibleBuildDests: Territory[];
-  legalViasByUnitID: { [key: string]: LegalVia[] };
+  legalViasByUnitID: { [key: UnitID]: LegalVia[] };
+  // The inner keys are provinces
+  legalConvoysByUnitID: {
+    [key: UnitID]: { [key: string]: { [key: string]: LegalConvoy } };
+  };
+  hasAnyLegalConvoysByUnitID: { [key: UnitID]: boolean };
   // The inner key is province
-  legalConvoysByUnitID: { [key: string]: { [key: string]: LegalConvoy[] } };
-  hasAnyLegalConvoysByUnitID: { [key: string]: boolean };
-  // The inner key is province
-  legalSupportsByUnitID: { [key: string]: { [key: string]: LegalSupport[] } };
+  legalSupportsByUnitID: {
+    [key: UnitID]: { [key: string]: LegalSupport[] };
+  };
 }
 
 // Returns all destination territories that a unit can legally move to on its own.
@@ -54,12 +60,12 @@ export function getAllLegalMoveDestsByUnitID(
   overview: GameOverviewResponse,
   data: GameData,
 ): {
-  [key: string]: Territory[];
+  [key: UnitID]: Territory[];
 } {
   if (overview.phase !== "Diplomacy") {
     return {};
   }
-  const legalMoveDestsByUnitID: { [key: string]: Territory[] } = {};
+  const legalMoveDestsByUnitID: { [key: UnitID]: Territory[] } = {};
 
   Object.entries(data.units).forEach(([unitID, unit]) => {
     const legalDests: Territory[] = [];
@@ -90,14 +96,14 @@ export function getAllLegalRetreatDestsByUnitID(
   data: GameData,
   maps: GameStateMaps,
 ): {
-  [key: string]: Territory[];
+  [key: UnitID]: Territory[];
 } {
   if (overview.phase !== "Retreats") {
     return {};
   }
-  const legalRetreatDestsByUnitID: { [key: string]: Territory[] } = {};
+  const legalRetreatDestsByUnitID: { [key: UnitID]: Territory[] } = {};
 
-  const provinceStatusByProvID: { [key: string]: IProvinceStatus } = {};
+  const provinceStatusByProvID: { [key: ProvinceID]: IProvinceStatus } = {};
   data.territoryStatuses.forEach((provinceStatus) => {
     provinceStatusByProvID[provinceStatus.id] = provinceStatus;
   });
@@ -117,7 +123,7 @@ export function getAllLegalRetreatDestsByUnitID(
     const iTerr = data.territories[unit.terrID];
     const borderKind = unit.type === UnitType.Army ? "a" : "f";
     // If non-null, a dislodger occupied our province coming from this province
-    const occupiedFromProvID: string | null = provStatus.occupiedFromTerrID
+    const occupiedFromProvID: ProvinceID | null = provStatus.occupiedFromTerrID
       ? maps.terrIDToProvinceID[provStatus.occupiedFromTerrID]
       : null;
     iTerr.CoastalBorders.forEach((border) => {
@@ -188,7 +194,7 @@ export function getAllPossibleBuildDests(
 
 interface PathToCoast {
   dest: Territory;
-  provIDPath: string[];
+  provIDPath: UnitID[];
 }
 
 // Returns all legal convoy orders.
@@ -202,19 +208,19 @@ export function getAllLegalConvoys(
   data: GameData,
   maps: GameStateMaps,
 ): [
-  { [key: string]: LegalVia[] },
-  { [key: string]: { [key: string]: LegalConvoy[] } },
+  { [key: UnitID]: LegalVia[] },
+  { [key: UnitID]: { [key: string]: { [key: string]: LegalConvoy } } },
 ] {
   if (overview.phase !== "Diplomacy") {
     return [{}, {}];
   }
   const ourCountryID = overview.user.member.countryID.toString();
-  const provinceStatusByProvID: { [key: string]: IProvinceStatus } = {};
+  const provinceStatusByProvID: { [key: ProvinceID]: IProvinceStatus } = {};
   data.territoryStatuses.forEach((provinceStatus) => {
     provinceStatusByProvID[provinceStatus.id] = provinceStatus;
   });
 
-  const legalViasByUnitID: { [key: string]: LegalVia[] } = {};
+  const legalViasByUnitID: { [key: UnitID]: LegalVia[] } = {};
   Object.entries(data.units).forEach(([unitID, unit]) => {
     // If this unit is not an army, then don't compute.
     if (unit.type !== UnitType.Army) {
@@ -225,12 +231,12 @@ export function getAllLegalConvoys(
     const legalViasByDest: { [key: string]: LegalVia } = {};
 
     // Perform DFS to find every location we can reach, and a path that does it.
-    const reachedProvIDs = new Set<string>();
+    const reachedProvIDs = new Set<ProvinceID>();
     reachedProvIDs.add(initialProvID);
 
     const searchAllNeighbors = function (
       iTerr: ITerritory,
-      pathSoFar: string[],
+      pathSoFar: ProvinceID[],
     ) {
       // Use Borders instead of CoastalBorders.
       // Borders appears to be province-level adjacency, whereas CoastalBoarders
@@ -280,11 +286,10 @@ export function getAllLegalConvoys(
   // We start in the middle at the fleet and use DFS to compute paths going outward
   // to armies and to coastal provinces.
   // The cartesian product of these two gives us all our results.
-  // Note that when taking such a cartesian product, the final paths may
-  // self-intersect. This is okay! We permit this.
+  // We filter the results for paths that don't re-use the same fleet more than once.
 
   const legalConvoysByUnitID: {
-    [key: string]: { [key: string]: LegalConvoy[] };
+    [key: UnitID]: { [key: string]: { [key: string]: LegalConvoy } };
   } = {};
   Object.entries(data.units).forEach(([unitID, unit]) => {
     // If this unit is owned by someone else or isn't a fleet on a sea, then don't compute.
@@ -302,12 +307,12 @@ export function getAllLegalConvoys(
     const initialProvID = unit.terrID;
 
     // Perform DFS to find every coastal army and coast we can reach, and a path that does it.
-    const reachedProvIDs = new Set<string>();
+    const reachedProvIDs = new Set<ProvinceID>();
     reachedProvIDs.add(initialProvID);
 
     const searchAllNeighbors = function (
       iTerr: ITerritory,
-      pathSoFar: string[],
+      pathSoFar: ProvinceID[],
     ) {
       // Use Borders instead of CoastalBorders.
       // Borders appears to be province-level adjacency, whereas CoastalBoarders
@@ -319,14 +324,15 @@ export function getAllLegalConvoys(
           if (reachedProvIDs.has(nextProvID)) {
             return;
           }
-          reachedProvIDs.add(nextProvID);
           // If it's a sea, then we recurse, so long as there is a unit there.
           const nextITerr = data.territories[nextProvID];
           if (nextITerr.type === "Sea") {
             if (provinceStatusByProvID[nextProvID]?.unitID) {
+              reachedProvIDs.add(nextProvID);
               pathSoFar.push(nextProvID);
               searchAllNeighbors(nextITerr, pathSoFar);
               pathSoFar.pop();
+              reachedProvIDs.delete(nextProvID);
             }
           }
           // Otherwise it's not a sea. Then we terminate.
@@ -347,10 +353,11 @@ export function getAllLegalConvoys(
     };
     searchAllNeighbors(data.territories[initialProvID], [initialProvID]);
 
-    // Now putting together each path to a coast army with each path to a coast
+    // Now putting together paths to each unique coast army with paths to a coast
     // gives us our final convoys that pass through this fleet.
-    const legalConvoysByConvoyeeTerritory: { [key: string]: LegalConvoy[] } =
-      {};
+    const legalConvoysByConvoyeeTerritory: {
+      [key: string]: { [key: string]: LegalConvoy };
+    } = {};
     pathsToCoastalArmy.forEach((pathToCoastalArmy) => {
       const provIDPath1 = [...pathToCoastalArmy.provIDPath];
       // Make sure the path contains the starting location, the flip it and pop
@@ -360,21 +367,46 @@ export function getAllLegalConvoys(
       provIDPath1.push(maps.territoryToTerrID[pathToCoastalArmy.dest]);
       provIDPath1.reverse();
       provIDPath1.pop();
-      const legalConvoys: LegalConvoy[] = [];
+
+      const provIDPath1Set = new Set(provIDPath1);
+
+      if (!legalConvoysByConvoyeeTerritory[pathToCoastalArmy.dest]) {
+        legalConvoysByConvoyeeTerritory[pathToCoastalArmy.dest] = {};
+      }
+      const legalConvoysByDestination =
+        legalConvoysByConvoyeeTerritory[pathToCoastalArmy.dest];
+
       pathsToCoast.forEach((pathToCoast) => {
         // Cannot convoy from a location to itself.
-        if (pathToCoast.dest !== pathToCoastalArmy.dest) {
-          legalConvoys.push({
+        if (pathToCoast.dest === pathToCoastalArmy.dest) return;
+        // If we already found a valid convoy for this army to this dest, skip
+        if (legalConvoysByDestination[pathToCoast.dest]) return;
+
+        // Check whether the to the destination overlaps with the path to the army
+        if (
+          pathToCoast.provIDPath.every(
+            (provIDInPath) => !provIDPath1Set.has(provIDInPath),
+          )
+        ) {
+          legalConvoysByDestination[pathToCoast.dest] = {
             src: pathToCoastalArmy.dest,
             dest: pathToCoast.dest,
             provIDPath1,
             provIDPath2: pathToCoast.provIDPath,
-          });
+          };
         }
       });
-      legalConvoysByConvoyeeTerritory[pathToCoastalArmy.dest] = legalConvoys;
     });
 
+    // Filter out all armies from the map that didn't find a valid way to convoy somewhere
+    const convoyeeSrcs = Object.keys(legalConvoysByConvoyeeTerritory);
+    convoyeeSrcs.forEach((convoyeeSrc) => {
+      if (
+        Object.keys(legalConvoysByConvoyeeTerritory[convoyeeSrc]).length <= 0
+      ) {
+        delete legalConvoysByConvoyeeTerritory[convoyeeSrc];
+      }
+    });
     legalConvoysByUnitID[unitID] = legalConvoysByConvoyeeTerritory;
   });
 
@@ -389,14 +421,14 @@ export function getAllLegalSupportsByUnitID(
   overview: GameOverviewResponse,
   data: GameData,
   maps: GameStateMaps,
-  legalMoveDestsByUnitID: { [key: string]: Territory[] },
-  legalViasByUnitID: { [key: string]: LegalVia[] },
-): { [key: string]: { [key: string]: LegalSupport[] } } {
+  legalMoveDestsByUnitID: { [key: UnitID]: Territory[] },
+  legalViasByUnitID: { [key: UnitID]: LegalVia[] },
+): { [key: UnitID]: { [key: ProvinceID]: LegalSupport[] } } {
   if (overview.phase !== "Diplomacy") {
     return {};
   }
   const legalSupportsByUnitID: {
-    [key: string]: { [key: string]: LegalSupport[] };
+    [key: UnitID]: { [key: ProvinceID]: LegalSupport[] };
   } = {};
 
   const ourCountryID = overview.user.member.countryID.toString();
@@ -406,11 +438,11 @@ export function getAllLegalSupportsByUnitID(
       return;
     }
 
-    const legalSupportsBySrc: { [key: string]: LegalSupport[] } = {};
+    const legalSupportsBySrc: { [key: ProvinceID]: LegalSupport[] } = {};
     const addSupport = function (
       src: Province,
       dest: Province,
-      convoyProvIDPath: string[] | null,
+      convoyProvIDPath: ProvinceID[] | null,
     ) {
       if (!legalSupportsBySrc[src]) {
         legalSupportsBySrc[src] = [];
@@ -500,7 +532,7 @@ export function getLegalOrders(
   const hasAnyLegalConvoysByUnitID = Object.fromEntries(
     Object.entries(legalConvoysByUnitID).map(([unitID, convoysBySrc]) => [
       unitID,
-      Object.values(convoysBySrc).some((convoys) => convoys.length > 0),
+      Object.values(convoysBySrc).length > 0,
     ]),
   );
 

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
@@ -315,7 +315,7 @@ export default function processMapClick(
       // gotta click on an Army that is convoyable
       if (
         clickUnit?.type === "Army" &&
-        legalOrders.legalConvoysByUnitID[order.unitID][clickProvince].length > 0
+        legalOrders.legalConvoysByUnitID[order.unitID][clickProvince]
       ) {
         updateOrder(state, {
           fromTerrID: maps.territoryToTerrID[clickRootTerritory],
@@ -327,9 +327,10 @@ export default function processMapClick(
     } else {
       // click 2
       const fromProvince = maps.terrIDToProvince[order.fromTerrID];
-      const convoy = legalOrders.legalConvoysByUnitID[order.unitID][
-        fromProvince
-      ].find((c) => c.dest === clickRootTerritory);
+      const convoy =
+        legalOrders.legalConvoysByUnitID[order.unitID][fromProvince][
+          clickProvince
+        ];
       if (convoy) {
         updateOrder(state, {
           toTerrID: maps.territoryToTerrID[clickRootTerritory],


### PR DESCRIPTION
I thought I reviewed the code for webdip and that it didn't check convoy paths for self-intersection, but it looks like it actually does, in testing.

So, let's make things even more exponential and make the convoy generation code from the fleet side generate all convoy paths, then when doing the cartesian product it checks that path from the fleet to the coastal army doesn't intersect the path from the fleet to the coast.

I tested this on a position multiple armies could convoy between Italy and Scandinavia and it still only took 15 milliseconds in chrome to precompute the legal orders. And I verified that the orders whose *only* convoy paths would be self-intersecting that webdip was rejecting were now filtered out. I tried entering in some convoys that would be redundant (i.e. the path would not be self-intersecting even though the convoy path would not be minimal) and webdip accepted those, so I think this is the right filtering level.
