### PR TITLE
Reset order on phase change

### DIFF
--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -10,6 +10,7 @@ import getOrdersMeta from "../../../../map/getOrdersMeta";
 import { getUnitsLive } from "../../../../map/getUnits";
 import generateMaps from "../../../generateMaps";
 import getPhaseKey from "../../../getPhaseKey";
+import resetOrder from "../../../resetOrder";
 import updateOrdersMeta from "../../../updateOrdersMeta";
 import { getLegalOrders } from "./precomputeLegalOrders";
 
@@ -30,6 +31,7 @@ export default function fetchGameDataFulfilled(state: GameState, action): void {
   // Upon phase change, sweep away all orders from the previous turn
   if (oldPhaseKey !== newPhaseKey) {
     state.ordersMeta = {};
+    resetOrder(state);
   }
 
   state.data = action.payload;


### PR DESCRIPTION
I don't concretely know that there is a bug here, but it seems like a good prophylactic thing to do. There is no reason why we should want an in-progress order to carry over a phase transition, especially if we're going to also be clearing the ordersMeta.