### PR TITLE
Draw buttons

### DIFF
--- a/beta-src/src/components/ui/WDCountryTable.tsx
+++ b/beta-src/src/components/ui/WDCountryTable.tsx
@@ -23,6 +23,7 @@ import UnitsIcon from "./icons/country-table/WDUnits";
 import useViewport from "../../hooks/useViewport";
 import getDevice from "../../utils/getDevice";
 import WDCheckmarkIcon from "./icons/WDCheckmarkIcon";
+import Vote from "../../enums/Vote";
 
 interface WDCountryTableProps {
   countries: CountryTableData[];
@@ -154,51 +155,47 @@ const WDCountryTable: React.FC<WDCountryTableProps> = function ({
                   );
                 })}
               </TableRow>
-              {country.votes && (
-                <TableRow>
-                  <WDTableCell
+              <TableRow
+                sx={{ display: country.votes.length ? "contents" : "none" }}
+              >
+                <WDTableCell
+                  sx={{
+                    fontSize: "70%",
+                    paddingTop: "0px !important",
+                    fontWeight: 700,
+                  }}
+                  colSpan={columns.length}
+                >
+                  <Box
                     sx={{
-                      fontSize: "70%",
-                      paddingTop: "0px !important",
-                      fontWeight: 700,
+                      color: theme.palette.action.disabledBackground,
+                      display: "inline-block",
+                      marginRight: 1.5,
                     }}
-                    colSpan={columns.length}
                   >
-                    {Object.values(country.votes).reduce(
-                      (prev, curr) => prev + +curr,
-                      0,
-                    ) > 0 && (
-                      <Box
-                        sx={{
-                          color: theme.palette.action.disabledBackground,
-                          display: "inline-block",
-                          marginRight: 1.5,
-                        }}
-                      >
-                        VOTED
-                      </Box>
-                    )}
-                    {Object.entries(country.votes).map(
-                      (data) =>
-                        data[1] && (
-                          <Chip
-                            key={`${country.power}-vote-${data[0]}`}
-                            size="small"
-                            label={data[0].toUpperCase()}
-                            sx={{
-                              color: theme.palette.secondary.main,
-                              background: country.color,
-                              fontWeight: 900,
-                              fontSize: "90%",
-                              height: 14,
-                              marginRight: 1,
-                            }}
-                          />
-                        ),
-                    )}
-                  </WDTableCell>
-                </TableRow>
-              )}
+                    VOTED
+                  </Box>
+
+                  {Object.keys(Vote).map(
+                    (vote) =>
+                      country.votes.includes(vote) && (
+                        <Chip
+                          key={`${country.power}-vote-${vote}`}
+                          size="small"
+                          label={vote.toUpperCase()}
+                          sx={{
+                            color: theme.palette.secondary.main,
+                            background: country.color,
+                            fontWeight: 900,
+                            fontSize: "90%",
+                            height: 14,
+                            marginRight: 1,
+                          }}
+                        />
+                      ),
+                  )}
+                </WDTableCell>
+              </TableRow>
             </React.Fragment>
           ))}
         </TableBody>

--- a/beta-src/src/components/ui/WDInfoPanel.tsx
+++ b/beta-src/src/components/ui/WDInfoPanel.tsx
@@ -8,7 +8,10 @@ import { CountryTableData } from "../../interfaces/CountryTableData";
 import GameOverviewResponse from "../../state/interfaces/GameOverviewResponse";
 import useViewport from "../../hooks/useViewport";
 import getDevice from "../../utils/getDevice";
-import { toggleVoteStatus } from "../../state/game/game-api-slice";
+import {
+  gameApiSliceActions,
+  toggleVoteStatus,
+} from "../../state/game/game-api-slice";
 import { useAppDispatch } from "../../state/hooks";
 
 interface WDInfoPanelProps {
@@ -24,36 +27,20 @@ const WDInfoPanel: React.FC<WDInfoPanelProps> = function ({
   maxDelays,
   userCountry,
 }): React.ReactElement {
-  const [voteState, setVoteState] = React.useState(userCountry.votes);
   const [viewport] = useViewport();
   const device = getDevice(viewport);
   const dispatch = useAppDispatch();
 
-  React.useEffect(() => {
-    setVoteState(userCountry.votes);
-  }, [userCountry]);
-
-  const toggleVote = (voteName: Vote) => {
-    const voteKey = Vote[voteName];
-    const newVoteState = {
-      ...voteState,
-      [voteKey]: !voteState[voteKey],
-    };
-
-    const currentGameID = String(gameID);
-    const countryID = String(userCountry.countryID);
-
-    setVoteState(newVoteState);
-
+  const toggleVote = (voteKey: Vote) => {
+    dispatch(gameApiSliceActions.toggleVoteState(voteKey));
     dispatch(
       toggleVoteStatus({
-        countryID,
-        gameID: currentGameID,
-        vote: voteKey.charAt(0).toUpperCase() + voteKey.slice(1),
+        countryID: String(userCountry.countryID),
+        gameID: String(gameID),
+        vote: voteKey,
       }),
     );
   };
-
   const mobileLandscapeLayout =
     device === Device.MOBILE_LANDSCAPE ||
     device === Device.MOBILE_LG_LANDSCAPE ||
@@ -64,7 +51,7 @@ const WDInfoPanel: React.FC<WDInfoPanelProps> = function ({
   return (
     <Box>
       <Box sx={{ p: padding }}>
-        <WDVoteButtons toggleVote={toggleVote} voteState={voteState} />
+        <WDVoteButtons toggleVote={toggleVote} voteState={userCountry.votes} />
       </Box>
       <Box
         sx={{
@@ -77,7 +64,10 @@ const WDInfoPanel: React.FC<WDInfoPanelProps> = function ({
            * always show current user at the top
            *
            */
-          countries={[{ ...userCountry, votes: voteState }, ...countries]}
+          countries={[
+            { ...userCountry, votes: userCountry.votes },
+            ...countries,
+          ]}
         />
       </Box>
     </Box>

--- a/beta-src/src/components/ui/WDUI.tsx
+++ b/beta-src/src/components/ui/WDUI.tsx
@@ -77,11 +77,7 @@ const WDUI: React.FC = function (): React.ReactElement {
       abbr: abbrMap[member.country],
       color: theme.palette[memberCountry].main,
       power: memberCountry,
-      votes: {
-        cancel: member.votes.includes(capitalizeString(Vote[Vote.cancel])),
-        draw: member.votes.includes(capitalizeString(Vote[Vote.draw])),
-        pause: member.votes.includes(capitalizeString(Vote[Vote.pause])),
-      },
+      votes: member.votes,
     };
   };
 

--- a/beta-src/src/components/ui/WDVoteButtons.tsx
+++ b/beta-src/src/components/ui/WDVoteButtons.tsx
@@ -2,22 +2,15 @@ import * as React from "react";
 import { Stack } from "@mui/material";
 import WDButton from "./WDButton";
 import Vote from "../../enums/Vote";
-import VoteType from "../../types/Vote";
 import getDevice from "../../utils/getDevice";
 import useViewport from "../../hooks/useViewport";
 import Device from "../../enums/Device";
 import WDCheckmarkIcon from "./icons/WDCheckmarkIcon";
 
 interface voteProps {
-  voteState: VoteType;
+  voteState: string[];
   toggleVote: (vote: Vote) => void;
 }
-
-const voteLabel = {
-  draw: "Draw",
-  pause: "Pause",
-  cancel: "Cancel",
-};
 
 const WDVoteButtons: React.FC<voteProps> = function ({
   voteState,
@@ -31,7 +24,8 @@ const WDVoteButtons: React.FC<voteProps> = function ({
     device === Device.MOBILE;
   const padding = mobileLandscapeLayout ? "10px 10px" : "10px 18px";
   const spacing = mobileLandscapeLayout ? 1 : 2;
-  const commandButtons = Object.entries(voteState).map(([vote, status]) => {
+  const commandButtons = Object.keys(Vote).map((vote) => {
+    const status = voteState.includes(vote);
     return (
       <WDButton
         key={vote}
@@ -40,7 +34,7 @@ const WDVoteButtons: React.FC<voteProps> = function ({
         onClick={() => toggleVote(Vote[vote])}
         startIcon={status ? <WDCheckmarkIcon /> : ""}
       >
-        {voteLabel[vote]}
+        {vote}
       </WDButton>
     );
   });

--- a/beta-src/src/enums/Vote.ts
+++ b/beta-src/src/enums/Vote.ts
@@ -1,7 +1,7 @@
 enum Vote {
-  cancel,
-  draw,
-  pause,
+  Cancel = "Cancel",
+  Draw = "Draw",
+  Pause = "Pause",
 }
 
 export default Vote;

--- a/beta-src/src/interfaces/CountryTableData.ts
+++ b/beta-src/src/interfaces/CountryTableData.ts
@@ -1,5 +1,4 @@
 import Country from "../enums/Country";
-import VoteType from "../types/Vote";
 import { MemberData } from "./state/MemberData";
 
 export interface CountryTableData extends MemberData {
@@ -8,5 +7,5 @@ export interface CountryTableData extends MemberData {
   color: string;
   power: Country;
   unitNo: number;
-  votes: VoteType;
+  votes: string[];
 }

--- a/beta-src/src/interfaces/state/MemberData.ts
+++ b/beta-src/src/interfaces/state/MemberData.ts
@@ -23,5 +23,5 @@ export interface MemberData {
   unitNo: number;
   userID: number;
   username: string;
-  votes: unknown;
+  votes: string[];
 }

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -242,6 +242,16 @@ const gameApiSlice = createSlice({
     selectMessageCountryID(state, action) {
       state.messages.countryIDSelected = action.payload;
     },
+    toggleVoteState(state, action) {
+      const voteKey: string = action.payload;
+      let votes = current(state.overview.user.member.votes) as string[];
+      if (votes.includes(voteKey)) {
+        votes = votes.filter((vote) => vote !== voteKey);
+      } else {
+        votes = [...votes, voteKey];
+      }
+      state.overview.user.member.votes = votes;
+    },
   },
   extraReducers(builder) {
     builder

--- a/beta-src/src/types/Vote.ts
+++ b/beta-src/src/types/Vote.ts
@@ -1,7 +1,0 @@
-type VoteType = {
-  cancel: boolean;
-  draw: boolean;
-  pause: boolean;
-};
-
-export default VoteType;

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -25,7 +25,7 @@ export default function fetchGameDataFulfilled(state: GameState, action): void {
     action.payload.data.contextVars?.context,
     "<BAD NEW_DATA_KEY>",
   );
-  console.log(`fetchGameDataFulfilled  ${oldPhaseKey} -> ${newPhaseKey}`);
+  // console.log(`fetchGameDataFulfilled  ${oldPhaseKey} -> ${newPhaseKey}`);
 
   // Upon phase change, sweep away all orders from the previous turn
   if (oldPhaseKey !== newPhaseKey) {


### PR DESCRIPTION
Draw buttons were really flaky, you click them and then they would revert back after a second and then back agian.

This mostly fixes it by pushing all the state into the store. There are still some rare race conditions where there's an outstanding gameOverview fetch while you click the draw button, in which case 
1. You click Draw
2. After 0.5s the fetch returns, unselecting Draw
3. After 5 more seconds, it selects again.

Should we try to fix this?