### PR TITLE
Make phase change overlay show previous phase instead of latest

### DIFF
--- a/beta-src/src/components/controllers/WDMainController.tsx
+++ b/beta-src/src/components/controllers/WDMainController.tsx
@@ -7,6 +7,7 @@ import {
   gameOverview,
   gameData,
   gameStatus,
+  gameViewedPhase,
   loadGameData,
 } from "../../state/game/game-api-slice";
 import { useAppDispatch, useAppSelector } from "../../state/hooks";
@@ -24,6 +25,7 @@ const WDMainController: React.FC = function ({ children }): React.ReactElement {
   const overview = useAppSelector(gameOverview);
   const { data } = useAppSelector(gameData);
   const status = useAppSelector(gameStatus);
+  const viewedPhaseState = useAppSelector(gameViewedPhase);
 
   const { countryID } = overview.user.member;
 
@@ -77,12 +79,16 @@ const WDMainController: React.FC = function ({ children }): React.ReactElement {
       {showOverlay && (
         <WDGameProgressOverlay
           overview={overview}
+          status={status}
+          viewedPhaseState={viewedPhaseState}
           clickHandler={() => {
             setDisplayedPhaseKey(overviewKey);
-            // When the user clicks on the overlay to show the latest
-            // phase, this makes it also jump forward to show them the
-            // latest phase.
-            dispatch(gameApiSliceActions.changeViewedPhaseIdxBy(Infinity));
+            // When the user clicks on the overlay, we jump them to the latest phase
+            // that they've seen so far. If the game has moved on one or more phases past that
+            // then this phase will now be filled with the latest orders that the user has
+            // *not* yet seen (i.e. presumably they saw this phase when they were entering
+            // orders for it, before that phase ended and other powers' orders appeared).
+            dispatch(gameApiSliceActions.setViewedPhaseToLatestPhaseViewed());
           }}
         />
       )}

--- a/beta-src/src/components/ui/WDGameProgressOverlay.tsx
+++ b/beta-src/src/components/ui/WDGameProgressOverlay.tsx
@@ -1,7 +1,19 @@
 import { Box, Button, Stack } from "@mui/material";
 import * as React from "react";
 import GameOverviewResponse from "../../state/interfaces/GameOverviewResponse";
+import GameStatusResponse from "../../state/interfaces/GameStatusResponse";
+import ViewedPhaseState from "../../state/interfaces/ViewedPhaseState";
 import formatPhaseForDisplay from "../../utils/formatPhaseForDisplay";
+import {
+  getGamePhaseSeasonYear,
+  getHistoricalPhaseSeasonYear,
+} from "../../utils/state/getPhaseSeasonYear";
+
+// Various of the buttons draw with a Z_INDEX of 2
+// So we set this overlay to a Z_INDEX of 4 to draw on top of them,
+// so that the user isn't scrolling phases and playing with the save and ready buttons
+// while this overlay sits on top.
+const Z_INDEX = 4;
 
 const centeredStyle = {
   position: "absolute",
@@ -13,6 +25,7 @@ const centeredStyle = {
   backgroundColor: "rgba(255,255,255,1)",
   p: "10px",
   borderRadius: "5px",
+  zIndex: Z_INDEX,
 };
 
 const overlayStyle = {
@@ -22,33 +35,93 @@ const overlayStyle = {
   height: "100%",
   width: "100%",
   backgroundColor: "rgba(52,52,52,0.6)",
+  zIndex: Z_INDEX,
 };
 
 interface WDGameProgressOverlayProps {
   overview: GameOverviewResponse;
+  status: GameStatusResponse;
+  viewedPhaseState: ViewedPhaseState;
   clickHandler: () => void;
 }
 
 const WDGameProgressOverlay: React.FC<WDGameProgressOverlayProps> = function ({
   overview,
+  status,
+  viewedPhaseState,
   clickHandler,
 }) {
   let innerElem;
   if (["Diplomacy", "Retreats", "Builds"].includes(overview.phase)) {
-    innerElem = (
-      <Stack direction="column" alignItems="center">
-        <Box sx={{ m: "4px" }}>Game progressed to a new phase...</Box>
+    if (status.phases.length <= 1) {
+      innerElem = (
+        <Stack direction="column" alignItems="center">
+          <Box sx={{ m: "4px" }}>Game progressed to a new phase...</Box>
+          <Button
+            size="large"
+            variant="contained"
+            color="success"
+            onClick={clickHandler}
+          >
+            View {overview.season} {overview.year}{" "}
+            {formatPhaseForDisplay(overview.phase)}
+          </Button>
+        </Stack>
+      );
+    } else {
+      const stuffToRender: React.ReactElement[] = [];
+      for (
+        let idx = viewedPhaseState.latestPhaseViewed;
+        idx < status.phases.length - 1;
+        idx += 1
+      ) {
+        const [phase, season, year] = getHistoricalPhaseSeasonYear(status, idx);
+        stuffToRender.push(
+          <Box key={`progressBox${idx}`} sx={{ m: "4px" }}>
+            Finished phase {`${season} ${year} ${formatPhaseForDisplay(phase)}`}
+            .
+          </Box>,
+        );
+      }
+
+      const [phase, season, year] = getGamePhaseSeasonYear(
+        overview.phase,
+        overview.season,
+        overview.year,
+      );
+      stuffToRender.push(
+        <Box sx={{ m: "4px" }} key="newPhaseMsgBox">
+          Beginning new phase{" "}
+          {`${season} ${year} ${formatPhaseForDisplay(phase)}`}.
+        </Box>,
+      );
+
+      const [oldPhase, oldSeason, oldYear] = getHistoricalPhaseSeasonYear(
+        status,
+        viewedPhaseState.latestPhaseViewed,
+      );
+      const buttonLabel = `View orders for ${oldSeason} ${oldYear} ${formatPhaseForDisplay(
+        oldPhase,
+      )}`;
+
+      stuffToRender.push(
         <Button
           size="large"
           variant="contained"
           color="success"
           onClick={clickHandler}
+          key="newPhaseOverlayButton"
         >
-          View {overview.season} {overview.year}{" "}
-          {formatPhaseForDisplay(overview.phase)}
-        </Button>
-      </Stack>
-    );
+          {buttonLabel}
+        </Button>,
+      );
+
+      innerElem = (
+        <Stack direction="column" alignItems="center">
+          {stuffToRender}
+        </Stack>
+      );
+    }
   } else if (overview.phase === "Pre-game") {
     innerElem = (
       <Box>

--- a/beta-src/src/components/ui/WDPhaseUI.tsx
+++ b/beta-src/src/components/ui/WDPhaseUI.tsx
@@ -17,7 +17,7 @@ const WDPhaseUI: React.FC = function (): React.ReactElement {
   const { phaseMinutes, processTime, phase, season, year } =
     useAppSelector(gameOverview);
   const gameStatusData = useAppSelector(gameStatus);
-  const { viewedPhaseIdx } = useAppSelector(gameViewedPhase);
+  const { viewedPhaseIdx, latestPhaseViewed } = useAppSelector(gameViewedPhase);
 
   const phaseSeconds = phaseMinutes * 60;
   const [gamePhase, gameSeason, gameYear] = getGamePhaseSeasonYear(
@@ -29,6 +29,8 @@ const WDPhaseUI: React.FC = function (): React.ReactElement {
     gameStatusData,
     viewedPhaseIdx,
   );
+  const animateForwardGlow =
+    latestPhaseViewed < gameStatusData.phases.length - 1;
 
   return (
     <Box
@@ -45,6 +47,7 @@ const WDPhaseUI: React.FC = function (): React.ReactElement {
       <WDPillScroller
         backwardDisabled={viewedPhaseIdx === 0}
         forwardDisabled={viewedPhaseIdx === gameStatusData.phases.length - 1}
+        animateForwardGlow={animateForwardGlow}
         viewedPhase={viewedPhase}
         viewedSeason={viewedSeason}
         viewedYear={viewedYear}

--- a/beta-src/src/components/ui/WDPillScroller.tsx
+++ b/beta-src/src/components/ui/WDPillScroller.tsx
@@ -11,6 +11,7 @@ import formatPhaseForDisplay from "../../utils/formatPhaseForDisplay";
 interface WDPillScrollerProps {
   backwardDisabled: boolean;
   forwardDisabled: boolean;
+  animateForwardGlow: boolean;
   viewedPhase: string;
   viewedSeason: Season;
   viewedYear: number;
@@ -19,6 +20,7 @@ interface WDPillScrollerProps {
 const WDPillScroller: React.FC<WDPillScrollerProps> = function ({
   backwardDisabled,
   forwardDisabled,
+  animateForwardGlow,
   viewedPhase,
   viewedSeason,
   viewedYear,
@@ -53,6 +55,7 @@ const WDPillScroller: React.FC<WDPillScrollerProps> = function ({
         className="WDScroll--Forward"
         direction={ScrollButtonState.FORWARD}
         disabled={forwardDisabled}
+        doAnimateGlow={animateForwardGlow}
         onClick={() => {
           dispatch(gameApiSliceActions.changeViewedPhaseIdxBy(1));
         }}

--- a/beta-src/src/components/ui/WDScrollButton.tsx
+++ b/beta-src/src/components/ui/WDScrollButton.tsx
@@ -7,6 +7,7 @@ interface ScrollButtonProps {
   className: string;
   direction: ScrollButtonState;
   disabled?: boolean;
+  doAnimateGlow?: boolean;
   onClick?: React.MouseEventHandler<HTMLButtonElement> | undefined;
 }
 
@@ -14,6 +15,7 @@ const WDScrollButton: React.FC<ScrollButtonProps> = function ({
   className,
   direction,
   disabled,
+  doAnimateGlow,
   onClick,
 }): React.ReactElement {
   return (
@@ -27,6 +29,8 @@ const WDScrollButton: React.FC<ScrollButtonProps> = function ({
           backgroundColor: "#fff",
           boxShadow: "none",
         },
+        animation:
+          doAnimateGlow && !disabled ? "scrollglowing 1.5s ease infinite" : "",
       }}
       className={className}
       disabled={disabled}
@@ -34,6 +38,20 @@ const WDScrollButton: React.FC<ScrollButtonProps> = function ({
       onClick={onClick}
       variant="contained"
     >
+      <style>
+        {`
+        @keyframes scrollglowing {
+          0% {
+            background-color: #66ff55;
+          }
+          50% {
+            background-color: #ffffff;
+          }
+          100% {
+            background-color: #66ff55;
+          }
+        }`}
+      </style>
       <WDPhaseArrowIcon direction={direction} disabled={disabled} />
     </Button>
   );
@@ -41,6 +59,7 @@ const WDScrollButton: React.FC<ScrollButtonProps> = function ({
 
 WDScrollButton.defaultProps = {
   disabled: false,
+  doAnimateGlow: false,
   onClick: undefined,
 };
 

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -232,6 +232,14 @@ const gameApiSlice = createSlice({
       newIdx = Math.min(newIdx, state.status.phases.length - 1);
       newIdx = Math.max(newIdx, 0);
       state.viewedPhaseState.viewedPhaseIdx = newIdx;
+      state.viewedPhaseState.latestPhaseViewed = Math.max(
+        state.viewedPhaseState.latestPhaseViewed,
+        newIdx,
+      );
+    },
+    setViewedPhaseToLatestPhaseViewed(state) {
+      state.viewedPhaseState.viewedPhaseIdx =
+        state.viewedPhaseState.latestPhaseViewed;
     },
     setAlert(state, action) {
       setAlert(state.alert, action.payload);

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -38,6 +38,7 @@ const initialState: GameState = {
   territoriesMeta: {},
   viewedPhaseState: {
     viewedPhaseIdx: 0,
+    latestPhaseViewed: 0,
   },
   overview: {
     alternatives: "",

--- a/beta-src/src/state/interfaces/ViewedPhaseState.ts
+++ b/beta-src/src/state/interfaces/ViewedPhaseState.ts
@@ -2,6 +2,8 @@
 export interface ViewedPhaseState {
   // The index of the phase currently being viewed, in the gameState.phases array.
   viewedPhaseIdx: number;
+  // The index of the latest phase that the user has viewed.
+  latestPhaseViewed: number;
 }
 
 export default ViewedPhaseState;

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameStatus/fulfilled.ts
@@ -11,10 +11,10 @@ export default function fetchGameStatusFulfilled(
   // console.log("fetchGameStatusFulfilled");
   state.apiStatus = "succeeded";
 
-  // If the user is scrolled to the current phase, make the viewed
-  // phase track the current phase
-  if (state.viewedPhaseState.viewedPhaseIdx >= state.status.phases.length - 1) {
+  // If this is the initial update, then jump to the most recent state upon load
+  if (state.status.phases.length <= 0 && action.payload.phases.length > 0) {
     state.viewedPhaseState.viewedPhaseIdx = action.payload.phases.length - 1;
+    state.viewedPhaseState.latestPhaseViewed = action.payload.phases.length - 1;
   }
 
   state.status = action.payload;


### PR DESCRIPTION
Okay, the game phase change overlay now takes you to the **latest phase you have viewed**.

That's the phase that will generally be the **first** phase with new orders you want to see, because presumably you've looked at that phase but before there were the other player's orders displayed on it.

The careful phrasing of "latest phase you have viewed" is so that we can handle multiple phases passing without any interaction from the user. For example here's a screen where a movement *and* a retreat phase passed before the user acknowledged it. The overlay popup is "smart" and stacks up both of the "Finished phase" messages and offers to take the user to the first one.

![image](https://user-images.githubusercontent.com/11942395/171770424-e6e9240b-72ce-4303-abaf-7caac3d1910d.png)

You can also see the button in the upper left glowing green animatedly now. It will glow so long as the latest phase the user has viewed isn't the latest phase of the game.

I also changed the z-index of the overlay to stop users from being able to click on the buttons before acknowledging the overlay.
