### PR TITLE
Fix arrow drawing crash

### DIFF
--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -73,6 +73,8 @@ export function getTargetXYWH(
       const toTerritoryData = TerritoryMap[toTerritoryName].provinceMapData;
       const { unitSlotName } = TerritoryMap[toTerritoryName];
 
+      x = toTerritoryData.x;
+      y = toTerritoryData.y;
       if (toTerritoryData.unitSlotsBySlotName[unitSlotName]) {
         x += toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.x;
         y += toTerritoryData.unitSlotsBySlotName[unitSlotName].arrowReceiver.y;


### PR DESCRIPTION
These two lines were lost in a recent pr by accident, causing arrow drawing for dislodged units to screw up. Fix it.