### PR TITLE
Handled 'finished' phase properly

### DIFF
--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -67,7 +67,10 @@ const WDMapController: React.FC = function (): React.ReactElement {
   const maps = useAppSelector(gameMaps);
 
   const updateForPhase = () => {
-    if (viewedPhaseState.viewedPhaseIdx >= status.phases.length - 1) {
+    if (
+      viewedPhaseState.viewedPhaseIdx >= status.phases.length - 1 &&
+      status.status === "Playing"
+    ) {
       // Convert from our internal order representation to webdip's
       // historical representation of orders so that we draw
       // our internal orders and webdip's historical orders

--- a/beta-src/src/components/ui/WDGameProgressOverlay.tsx
+++ b/beta-src/src/components/ui/WDGameProgressOverlay.tsx
@@ -52,7 +52,9 @@ const WDGameProgressOverlay: React.FC<WDGameProgressOverlayProps> = function ({
   clickHandler,
 }) {
   let innerElem;
-  if (["Diplomacy", "Retreats", "Builds"].includes(overview.phase)) {
+  if (
+    ["Diplomacy", "Retreats", "Builds", "Finished"].includes(overview.phase)
+  ) {
     if (status.phases.length <= 1) {
       innerElem = (
         <Stack direction="column" alignItems="center">


### PR DESCRIPTION
1. When progressing to finish phase, show a button so you don't get wedged.
2. Display the last historical phase properly when the game is drawn (don't incorrectly try to show it as a current playable phase).