### PR TITLE
Faded out invisible components should not receive clicks

### DIFF
--- a/beta-src/src/assets/css/App.css
+++ b/beta-src/src/assets/css/App.css
@@ -12,4 +12,5 @@
 .fade-out {
   opacity: 0;
   transition: opacity 0.5s ease-out;
+  pointer-events: none;
 }


### PR DESCRIPTION
Fixes the bug Noam identified where E med or aegean were hard to click on.

Edit: screenshot
![image](https://user-images.githubusercontent.com/11942395/171951670-280c4552-28eb-4856-ae49-6c7a745f5658.png)

Pre-the change in this PR, the modal shown blocks clicks even after it fades to be invisible. This is a much more noticeable problem on mobile of course, since on desktop you generally have the window big enough that you aren't trying to click in that place.