### PR TITLE
Fix invisible boxes blocking clicks

### DIFF
--- a/beta-src/src/components/ui/WDButton.tsx
+++ b/beta-src/src/components/ui/WDButton.tsx
@@ -32,6 +32,7 @@ const WDButton: React.FC<WDButtonProps> = function ({
       style={{
         animation:
           doAnimateGlow && !disabled ? "glowing 1.5s ease infinite" : "",
+        pointerEvents: "auto",
       }}
     >
       <style>

--- a/beta-src/src/components/ui/WDPhaseUI.tsx
+++ b/beta-src/src/components/ui/WDPhaseUI.tsx
@@ -42,6 +42,7 @@ const WDPhaseUI: React.FC = function (): React.ReactElement {
         height: 40,
         marginTop: "3px",
         marginRight: "55px", // for right side icons
+        pointerEvents: "none", // this box is invisible and used for layout alone, it shouldn't mask out clicks behind it
       }}
     >
       <WDPillScroller

--- a/beta-src/src/components/ui/WDPositionContainer.tsx
+++ b/beta-src/src/components/ui/WDPositionContainer.tsx
@@ -45,6 +45,7 @@ const WDPositionContainer: React.FC<WDPositionContainerProps> = function ({
         touchAction: "none",
         position: "absolute",
         zIndex: Z_INDEX,
+        pointerEvents: "none", // this component is for layout alone, it shouldn't mask out clicks behind it
         ...placement,
       }}
     >

--- a/beta-src/src/components/ui/WDScrollButton.tsx
+++ b/beta-src/src/components/ui/WDScrollButton.tsx
@@ -31,6 +31,7 @@ const WDScrollButton: React.FC<ScrollButtonProps> = function ({
         },
         animation:
           doAnimateGlow && !disabled ? "scrollglowing 1.5s ease infinite" : "",
+        pointerEvents: "auto",
       }}
       className={className}
       disabled={disabled}

--- a/beta-src/src/components/ui/WDUI.tsx
+++ b/beta-src/src/components/ui/WDUI.tsx
@@ -173,6 +173,7 @@ const WDUI: React.FC = function (): React.ReactElement {
         <Box
           sx={{
             pt: "15px",
+            pointerEvents: "auto",
           }}
           ref={popoverTrigger}
         >

--- a/beta-src/src/components/ui/icons/WDHomeIcon.tsx
+++ b/beta-src/src/components/ui/icons/WDHomeIcon.tsx
@@ -13,6 +13,9 @@ const WDHomeIcon: React.FC<NavIconProps> = function ({
       height={40}
       width={40}
       xmlns="http://www.w3.org/2000/svg"
+      style={{
+        pointerEvents: "auto",
+      }}
     >
       {iconState === UIState.ACTIVE && (
         <circle cx="20" cy="20" r="20" fill="#000" />


### PR DESCRIPTION
Invisible boxes were absorbing clicks. This was particularly bad on mobile, where the invisible boxes could overlap stuff and prevent clicks on other useful parts of the UI, as seen in this screenshot stopping clicks on the home button.

![image](https://user-images.githubusercontent.com/11942395/171955081-dede09fe-dab8-46c2-9f3a-3b7bc4c0c5fc.png)

We fix this by disabling pointer-events on several of the major boxes that are invisible but used for positioning.
However, since pointer-events is inherited down through the dom, we need to re-enable it selectively on some of the various components within those boxes that do need clicks.

I tried a quick test clicking on stuff and I didn't notice anything further that needed to be clickable but wasn't.