### PR TITLE
Fix drawing order

### DIFF
--- a/beta-src/src/components/map/components/WDProvinceBorderHighlight.tsx
+++ b/beta-src/src/components/map/components/WDProvinceBorderHighlight.tsx
@@ -1,0 +1,35 @@
+import * as React from "react";
+import { ProvinceMapData } from "../../../interfaces";
+
+interface WDProvinceBorderHighlightProps {
+  provinceMapData: ProvinceMapData;
+}
+
+const WDProvinceBorderHighlight: React.FC<WDProvinceBorderHighlightProps> =
+  function ({ provinceMapData }): React.ReactElement {
+    const { province } = provinceMapData;
+
+    return (
+      <svg
+        height={provinceMapData.height}
+        id={`${province}-province-overlay`}
+        viewBox={provinceMapData.viewBox}
+        width={provinceMapData.width}
+        x={provinceMapData.x}
+        y={provinceMapData.y}
+        overflow="visible"
+      >
+        <path
+          d={provinceMapData.path}
+          fill="none"
+          fillOpacity={0.0}
+          id={`${province}-choice-outline`}
+          stroke="black"
+          strokeOpacity={1}
+          strokeWidth={5}
+        />
+      </svg>
+    );
+  };
+
+export default WDProvinceBorderHighlight;

--- a/beta-src/src/components/map/components/WDProvinceOverlay.tsx
+++ b/beta-src/src/components/map/components/WDProvinceOverlay.tsx
@@ -1,26 +1,21 @@
-import { useTheme } from "@mui/material";
 import * as React from "react";
 import UIState from "../../../enums/UIState";
-import { Coordinates, ProvinceMapData } from "../../../interfaces";
-import OrderType from "../../../types/state/OrderType";
+import { ProvinceMapData } from "../../../interfaces";
 import UnitType from "../../../types/UnitType";
 import WDUnit from "../../ui/units/WDUnit";
 import WDUnitSlot from "./WDUnitSlot";
 import { Unit, UnitDrawMode } from "../../../utils/map/getUnits";
 import Province from "../../../enums/map/variants/classic/Province";
 import Territory from "../../../enums/map/variants/classic/Territory";
-import { IProvinceStatus } from "../../../models/Interfaces";
 
 interface WDProvinceOverlayProps {
   provinceMapData: ProvinceMapData;
   units: Unit[];
-  highlightChoice: boolean;
 }
 
 const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
   provinceMapData,
   units,
-  highlightChoice,
 }): React.ReactElement {
   const { province } = provinceMapData;
 
@@ -90,17 +85,6 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
       y={provinceMapData.y}
       overflow="visible"
     >
-      {highlightChoice && (
-        <path
-          d={provinceMapData.path}
-          fill="none"
-          fillOpacity={0.0}
-          id={`${province}-choice-outline`}
-          stroke="black"
-          strokeOpacity={1}
-          strokeWidth={5}
-        />
-      )}
       {provinceMapData.unitSlots
         .filter(({ name }) => name in unitFCs)
         .map(({ name, x, y }) => (

--- a/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
+++ b/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import WDProvince from "../../../components/WDProvince";
+import WDProvinceBorderHighlight from "../../../components/WDProvinceBorderHighlight";
 import WDProvinceOverlay from "../../../components/WDProvinceOverlay";
 import { Unit } from "../../../../../utils/map/getUnits";
 import provincesMapData from "../../../../../data/map/ProvincesMapData";
@@ -175,13 +176,23 @@ const WDBoardMap: React.FC<WDBoardMapProps> = function ({
     );
   });
 
+  const playableProvinceBorderHighlights = playableProvincesData
+    .filter((data) => provincesToChooseSet.has(data.province))
+    .map((data) => {
+      return (
+        <WDProvinceBorderHighlight
+          provinceMapData={data}
+          key={`${data.province}-province-border-highlight`}
+        />
+      );
+    });
+
   const playableProvinceOverlays = playableProvincesData.map((data) => {
     const highlightChoice = provincesToChooseSet.has(data.province);
     return (
       <WDProvinceOverlay
         provinceMapData={data}
         units={units}
-        highlightChoice={highlightChoice}
         key={`${data.province}-province-overlay`}
       />
     );
@@ -191,6 +202,9 @@ const WDBoardMap: React.FC<WDBoardMapProps> = function ({
     <g id="wD-boardmap-v10.3.4 1">
       <g id="unplayable">{unplayableProvinces}</g>
       <g id="playableProvinces">{playableProvinces}</g>
+      <g id="playableProvinceBorderHighlights">
+        {playableProvinceBorderHighlights}
+      </g>
       <g id="playableProvinceOverlays">{playableProvinceOverlays}</g>
     </g>
   );

--- a/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
+++ b/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
@@ -188,7 +188,6 @@ const WDBoardMap: React.FC<WDBoardMapProps> = function ({
     });
 
   const playableProvinceOverlays = playableProvincesData.map((data) => {
-    const highlightChoice = provincesToChooseSet.has(data.province);
     return (
       <WDProvinceOverlay
         provinceMapData={data}

--- a/beta-src/src/data/map/ProvincesMapData.ts
+++ b/beta-src/src/data/map/ProvincesMapData.ts
@@ -219,7 +219,7 @@ const mapDrawData: { [key in Province]: ProvinceMapDrawData } = {
     unitSlots: [
       {
         name: "main",
-        x: 0,
+        x: 14,
         y: 84,
         arrowReceiver: {
           x: 50,


### PR DESCRIPTION
Especially with the bigger units, there are many places where the unit slightly overlaps the border of a province, and depending on the drawing order of provinces, borders could still be drawn on top of the unit.

This fixes that, by splitting border drawing and unit drawing into separate components.

![image](https://user-images.githubusercontent.com/11942395/172660801-94548417-37ba-42e1-86c5-ebb419d82fb9.png)

Also, we go ahead to slightly adjust the position of a unit in Berlin to be better centered.
