### PR TITLE
Improve short arrows and adjust some arrow targets

### DIFF
--- a/beta-src/src/data/map/ProvincesMapData.ts
+++ b/beta-src/src/data/map/ProvincesMapData.ts
@@ -530,7 +530,7 @@ const mapDrawData: { [key in Province]: ProvinceMapDrawData } = {
         x: 0,
         y: 75,
         arrowReceiver: {
-          x: 45,
+          x: 40,
           y: 45,
         },
       },
@@ -2385,14 +2385,14 @@ const mapDrawData: { [key in Province]: ProvinceMapDrawData } = {
       {
         name: "main",
         x: 241,
-        y: 120,
+        y: 85,
       },
     ],
     unitSlots: [
       {
         name: "main",
         x: 230,
-        y: 45,
+        y: 95,
         arrowReceiver: {
           x: 200,
           y: 150,
@@ -2869,8 +2869,8 @@ const mapDrawData: { [key in Province]: ProvinceMapDrawData } = {
     unitSlots: [
       {
         name: "main",
-        x: 83,
-        y: 111,
+        x: 87,
+        y: 105,
         arrowReceiver: {
           x: 35,
           y: 80,

--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -132,7 +132,7 @@ export function getArrowX1Y1X2Y2(
   // Draw the arrows slightly closer to a unit than their nominal size for the arrow source, the portion of
   // the unit's nominal size that the unit icon actually covers is a bit smaller and
   // the arrow looks a bit too far away otherwise.
-  const UNIT_SOURCE_SHRINK_FACTOR = 0.9;
+  const UNIT_SOURCE_SHRINK_FACTOR = 0.8;
   if (sourceType === "unit" || sourceType === "dislodger") {
     sourceWidth *= UNIT_SOURCE_SHRINK_FACTOR;
     sourceHeight *= UNIT_SOURCE_SHRINK_FACTOR;
@@ -153,8 +153,6 @@ export function getArrowX1Y1X2Y2(
 }
 
 // See getTargetXYWH for a description of the possible types and identifiers.
-// If skipDrawingProportion is specified, will skip drawing the first
-// skipDrawingProportion-th of the line segment of the arrow.
 export default function drawArrowFunctional(
   arrowType: ArrowType,
   arrowColor: ArrowColor,


### PR DESCRIPTION
This situation is very confusing in Denmark.

![image](https://user-images.githubusercontent.com/11942395/172678142-3d4215a8-dc4a-43ef-87ab-7f529dec48ae.png)

* We move Skaggerack's unit location to be slightly further from Denmark's arrow receiver
* We adjust Baltic unit location down slightly to be less collinear.
* We make arrows generally attach closer to units so that generally across the whole map, short arrows are less confusing.

![image](https://user-images.githubusercontent.com/11942395/172678579-2b3be64f-ba27-4e4b-b4e7-c19de9e6d273.png)
