### PR TITLE
Partially fix standoff drawing

### DIFF
--- a/beta-src/src/components/controllers/WDMapController.tsx
+++ b/beta-src/src/components/controllers/WDMapController.tsx
@@ -43,7 +43,7 @@ interface WDMapControllerProps {
   territories: APITerritories;
   centersByProvince: { [key: string]: { ownerCountryID: string } };
   standoffs: StandoffInfo[];
-  isLatestPhase: boolean;
+  isLivePhase: boolean; // Game is live and user is viewing the latest phase?
 }
 
 const WDMapController: React.FC<WDMapControllerProps> = function ({
@@ -53,7 +53,7 @@ const WDMapController: React.FC<WDMapControllerProps> = function ({
   maps,
   territories,
   centersByProvince,
-  isLatestPhase,
+  isLivePhase,
   standoffs,
 }): React.ReactElement {
   const svgElement = React.useRef<SVGSVGElement>(null);
@@ -144,7 +144,7 @@ const WDMapController: React.FC<WDMapControllerProps> = function ({
         territories={territories}
         centersByProvince={centersByProvince}
         standoffs={standoffs}
-        isLatestPhase={isLatestPhase}
+        isLivePhase={isLivePhase}
       />
     </div>
   );

--- a/beta-src/src/components/map/WDMap.tsx
+++ b/beta-src/src/components/map/WDMap.tsx
@@ -21,7 +21,7 @@ interface WDMapProps {
   territories: APITerritories;
   centersByProvince: { [key: string]: { ownerCountryID: string } };
   standoffs: StandoffInfo[];
-  isLatestPhase: boolean;
+  isLivePhase: boolean; // Game is live and user is viewing the latest phase?
 }
 
 const WDMap: React.ForwardRefExoticComponent<
@@ -36,7 +36,7 @@ const WDMap: React.ForwardRefExoticComponent<
       territories,
       centersByProvince,
       standoffs,
-      isLatestPhase,
+      isLivePhase,
     },
     ref,
   ): React.ReactElement => (
@@ -56,7 +56,7 @@ const WDMap: React.ForwardRefExoticComponent<
             units={units}
             centersByProvince={centersByProvince}
             phase={phase}
-            isLatestPhase={isLatestPhase}
+            isLivePhase={isLivePhase}
           />
           <WDArrowContainer
             phase={phase}
@@ -66,8 +66,8 @@ const WDMap: React.ForwardRefExoticComponent<
             territories={territories}
             standoffs={standoffs}
           />
-          {isLatestPhase && <WDBuildContainer />}
-          {isLatestPhase && <WDFlyoutContainer units={units} />}
+          {isLivePhase && <WDBuildContainer />}
+          {isLivePhase && <WDFlyoutContainer units={units} />}
         </g>
       </g>
       <defs>

--- a/beta-src/src/components/map/components/WDArrowContainer.tsx
+++ b/beta-src/src/components/map/components/WDArrowContainer.tsx
@@ -24,6 +24,8 @@ import Territory from "../../../enums/map/variants/classic/Territory";
 
 // Indicates that we should draw this Province as having a standoff.
 export interface StandoffInfo {
+  // The webdip province ID of the standoff
+  provID: string;
   // The province of the standoff
   province: Province;
   // The source and destination of moves that caused the standoff

--- a/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
+++ b/beta-src/src/components/map/variants/classic/components/WDBoardMap.tsx
@@ -22,14 +22,14 @@ interface WDBoardMapProps {
   units: Unit[];
   centersByProvince: { [key: string]: { ownerCountryID: string } };
   phase: string;
-  isLatestPhase: boolean;
+  isLivePhase: boolean; // Game is live and user is viewing the latest phase?
 }
 
 const WDBoardMap: React.FC<WDBoardMapProps> = function ({
   units,
   centersByProvince,
   phase,
-  isLatestPhase,
+  isLivePhase,
 }): React.ReactElement {
   const gameDataResponse = useAppSelector(gameData);
   const maps = useAppSelector(gameMaps);
@@ -47,7 +47,7 @@ const WDBoardMap: React.FC<WDBoardMapProps> = function ({
 
   let provincesToHighlight: Province[] = [];
   let provincesToChoose: Province[] = [];
-  if (isLatestPhase && user) {
+  if (isLivePhase && user) {
     if (phase === "Diplomacy") {
       if (!curOrder.inProgress) {
         provincesToHighlight = [];

--- a/beta-src/src/components/ui/WDMain.tsx
+++ b/beta-src/src/components/ui/WDMain.tsx
@@ -268,7 +268,7 @@ const WDMain: React.FC = function (): React.ReactElement {
         }
       }
     });
-    standoffs = Object.values(standoffsByProvince);
+    standoffs = Object.values(standoffsByProvince) || [];
 
     // FIXME: Messy. After-the-fact, do some filtering of the standoffs to remove
     // some (but not all) of the above false positives. In particular, live phases

--- a/beta-src/src/components/ui/WDMain.tsx
+++ b/beta-src/src/components/ui/WDMain.tsx
@@ -37,10 +37,12 @@ const WDMain: React.FC = function (): React.ReactElement {
   const maps = useAppSelector(gameMaps);
 
   const updateForPhase = () => {
+    // Only do live viewing if game is not over and not spectating
+    const isPlayingGame = status.status === "Playing" && !!overview.user;
     if (
       viewedPhaseState.viewedPhaseIdx >= status.phases.length - 1 &&
-      status.status === "Playing" && // only live viewing if game not over
-      overview.user // only do live viewing if non-spectating
+      isPlayingGame &&
+      overview.user
     ) {
       // Convert from our internal order representation to webdip's
       // historical representation of orders so that we draw
@@ -183,7 +185,7 @@ const WDMain: React.FC = function (): React.ReactElement {
         units,
         orders: ordersHistorical,
         centersByProvince,
-        isLatestPhase: true,
+        isLivePhase: true,
       };
     }
 
@@ -194,7 +196,7 @@ const WDMain: React.FC = function (): React.ReactElement {
         units: [],
         orders: [],
         centersByProvince: {},
-        isLatestPhase: true,
+        isLivePhase: isPlayingGame,
       };
     }
 
@@ -224,10 +226,10 @@ const WDMain: React.FC = function (): React.ReactElement {
       units: unitsLive,
       orders: phaseHistorical.orders,
       centersByProvince,
-      isLatestPhase: false,
+      isLivePhase: false,
     };
   };
-  const { phase, units, orders, centersByProvince, isLatestPhase } =
+  const { phase, units, orders, centersByProvince, isLivePhase } =
     updateForPhase();
   const { territories } = data.data;
 
@@ -240,12 +242,21 @@ const WDMain: React.FC = function (): React.ReactElement {
     const standoffsByProvince: { [key: string]: StandoffInfo } = {};
     prevPhase.orders.forEach((order) => {
       if (order.type === "Move" && order.toTerrID) {
+        const provID = maps.terrIDToProvinceID[order.toTerrID];
         const province = maps.terrIDToProvince[order.toTerrID];
         if (!provincesWithUnits.has(province)) {
+          // FIXME: This logic is wrong because a unit might fail to move
+          // due to it being a convoy and the convoying fleet being dislodged!
+          // Rarely, this may cause us to graphically indicate a standoff on historical
+          // phases, when actually there was none.
+          // Probably the way to fix this is to get the API to give us the historical
+          // standoff status of different provinces - right now, it does NOT do so.
+          //
           // If we have a move order to a province but that province has no units now
           // then it's a standoff
           if (!standoffsByProvince[province]) {
             standoffsByProvince[province] = {
+              provID,
               province,
               attemptedMoves: [],
             };
@@ -258,6 +269,29 @@ const WDMain: React.FC = function (): React.ReactElement {
       }
     });
     standoffs = Object.values(standoffsByProvince);
+
+    // FIXME: Messy. After-the-fact, do some filtering of the standoffs to remove
+    // some (but not all) of the above false positives. In particular, live phases
+    // should always be correct, but historical phases that have two units that both
+    // move to the same location via convoy where their convoy fails due to the intervening
+    // fleets being dislodged will incorrectly depict a standoff there.
+    if (isLivePhase) {
+      const territoryStatusesByProvID = Object.fromEntries(
+        data.data.territoryStatuses.map((territoryStatus) => [
+          territoryStatus.id,
+          territoryStatus,
+        ]),
+      );
+      standoffs = standoffs.filter(
+        (standoff) =>
+          standoff.attemptedMoves.length >= 2 &&
+          territoryStatusesByProvID[standoff.provID].standoff,
+      );
+    } else {
+      standoffs = standoffs.filter(
+        (standoff) => standoff.attemptedMoves.length >= 2,
+      );
+    }
   }
 
   return (
@@ -271,7 +305,7 @@ const WDMain: React.FC = function (): React.ReactElement {
           territories={territories}
           centersByProvince={centersByProvince}
           standoffs={standoffs}
-          isLatestPhase={isLatestPhase}
+          isLivePhase={isLivePhase}
         />
         <WDUI orders={orders} />
       </WDMainController>


### PR DESCRIPTION
Currently we derive standoff drawing on historical phases from the previous orders since the API doesn't send it to us. We also do the same computation on live phases as well so that on all phases we can draw the orders that cause the standoff.

But there is a bug - if units fail to move to a province due to a failed convoy rather than due to bouncing in the target province , then on the retreat phase we incorrectly draw it as a standoff. Example: incorrect drawing in Norway.
![image](https://user-images.githubusercontent.com/11942395/172688231-30659d06-7cc8-49eb-abef-4f1cc40f71c1.png)

On live phases we fix this bug by checking against the genuine standoff status in the destination, and on historical phases we partially fix this bug by requiring that at least 2 units attempted to move to the province.

On historical phases there is still bad drawing if two units move to a location via convoy and neither gets in due to both failing their convoys. But this should be very rare, and it is hard to fix without the server API sending us the true standoff data historically, so we don't bother.

With the partial fix in this PR:
![image](https://user-images.githubusercontent.com/11942395/172688775-9a2790fe-11ad-4bff-b343-cfacbccd64c1.png)

