### PR TITLE
Button logic

### DIFF
--- a/beta-src/src/components/controllers/WDMainController.tsx
+++ b/beta-src/src/components/controllers/WDMainController.tsx
@@ -49,11 +49,18 @@ const WDMainController: React.FC = function ({ children }): React.ReactElement {
   // FIXME: for now, crazily fetch all messages every 5sec
   useInterval(dispatchFetchOverview, 5000);
 
+  const needsGameOverview = useAppSelector(
+    ({ game }) => game.needsGameOverview,
+  );
   const needsGameData = useAppSelector(({ game }) => game.needsGameData);
   const noPhase = ["Error", "Pre-game"].includes(overview.phase);
   const consistentPhase =
     noPhase || (overviewKey === statusKey && overviewKey === dataKey);
 
+  if (needsGameOverview && !noPhase) {
+    dispatch(gameApiSliceActions.setNeedsGameOverview(false));
+    dispatch(fetchGameOverview({ gameID: String(overview.gameID) }));
+  }
   if (needsGameData && !noPhase) {
     dispatch(gameApiSliceActions.setNeedsGameData(false));
     dispatch(

--- a/beta-src/src/components/ui/WDInfoPanel.tsx
+++ b/beta-src/src/components/ui/WDInfoPanel.tsx
@@ -10,9 +10,9 @@ import useViewport from "../../hooks/useViewport";
 import getDevice from "../../utils/getDevice";
 import {
   gameApiSliceActions,
-  toggleVoteStatus,
+  setVoteStatus,
 } from "../../state/game/game-api-slice";
-import { useAppDispatch } from "../../state/hooks";
+import { useAppSelector, useAppDispatch } from "../../state/hooks";
 
 interface WDInfoPanelProps {
   allCountries: CountryTableData[];
@@ -30,15 +30,19 @@ const WDInfoPanel: React.FC<WDInfoPanelProps> = function ({
   const [viewport] = useViewport();
   const device = getDevice(viewport);
   const dispatch = useAppDispatch();
+  const votingInProgress = useAppSelector(
+    (state) => state.game.votingInProgress,
+  );
 
   const toggleVote = (voteKey: Vote) => {
-    dispatch(gameApiSliceActions.toggleVoteState(voteKey));
     if (userCountry) {
+      const desiredVoteOn = userCountry.votes.includes(voteKey) ? "No" : "Yes";
       dispatch(
-        toggleVoteStatus({
+        setVoteStatus({
           countryID: String(userCountry.countryID),
           gameID: String(gameID),
           vote: voteKey,
+          voteOn: desiredVoteOn,
         }),
       );
     }
@@ -57,6 +61,7 @@ const WDInfoPanel: React.FC<WDInfoPanelProps> = function ({
           <WDVoteButtons
             toggleVote={toggleVote}
             voteState={userCountry.votes}
+            votingInProgress={votingInProgress}
           />
         </Box>
       )}

--- a/beta-src/src/components/ui/WDMoveControls.tsx
+++ b/beta-src/src/components/ui/WDMoveControls.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import { Stack, useTheme } from "@mui/material";
 import WDButton from "./WDButton";
-import Move from "../../enums/Move";
 import useViewport from "../../hooks/useViewport";
 import getDevice from "../../utils/getDevice";
 import Device from "../../enums/Device";
@@ -16,9 +15,18 @@ import {
   saveOrders,
 } from "../../state/game/game-api-slice";
 import UpdateOrder from "../../interfaces/state/UpdateOrder";
-import MoveStatus from "../../types/MoveStatus";
 import { RootState } from "../../state/store";
 import { OrderStatus } from "../../interfaces/state/MemberData";
+import OrderSubmission from "../../interfaces/state/OrderSubmission";
+
+enum Move {
+  SAVE = "save",
+  READY = "ready",
+}
+
+type MoveStatus = {
+  [key in Move]: boolean;
+};
 
 interface WDMoveControlsProps {
   orderStatus: OrderStatus;
@@ -33,6 +41,9 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
   const ordersMeta = useAppSelector(gameOrdersMeta);
   const status = useAppSelector(gameStatus);
   const viewedPhaseState = useAppSelector(gameViewedPhase);
+  const savingOrdersInProgress = useAppSelector(
+    (state) => state.game.savingOrdersInProgress,
+  );
 
   const viewingCurPhase =
     viewedPhaseState.viewedPhaseIdx >= status.phases.length - 1;
@@ -40,31 +51,6 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
   const currentOrderInProgress = useAppSelector(
     ({ game: { order } }: RootState) => order.inProgress,
   );
-  const [readyDisabled, setReadyDisabled] = React.useState(false);
-  const [gameState, setGameState] = React.useState<MoveStatus>({
-    save: false,
-    ready: false,
-  });
-
-  if (orderStatus.None && !readyDisabled) {
-    setReadyDisabled(true);
-  }
-
-  React.useEffect(() => {
-    if (orderStatus.Ready !== gameState.ready) {
-      setGameState((preState) => ({
-        ...preState,
-        [Move.READY]: orderStatus.Ready,
-      }));
-    }
-  }, [orderStatus]);
-
-  const toggleState = (move: Move) => {
-    setGameState((preState) => ({
-      ...preState,
-      [move]: !gameState[move],
-    }));
-  };
 
   const dispatch = useAppDispatch();
   const device = getDevice(viewport);
@@ -80,6 +66,59 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
       isMobile = false;
       break;
   }
+
+  const ordersMetaValues = Object.values(ordersMeta);
+  const ordersLength = ordersMetaValues.length;
+  const ordersSaved = ordersMetaValues.reduce(
+    (acc, meta) => acc + +meta.saved,
+    0,
+  );
+
+  let readyEnabled: boolean;
+  let saveEnabled: boolean;
+  let readyButtonText: string;
+  let saveButtonText: string;
+
+  // orderStatus contains what the server thinks our order status is.
+  if (savingOrdersInProgress === "readying") {
+    readyEnabled = false;
+    saveEnabled = false;
+    readyButtonText = "Readying...";
+    saveButtonText = "Save";
+  } else if (savingOrdersInProgress === "unreadying") {
+    readyEnabled = false;
+    saveEnabled = false;
+    readyButtonText = "Unreadying...";
+    saveButtonText = "Save";
+  } else if (savingOrdersInProgress === "saving") {
+    readyEnabled = false;
+    saveEnabled = false;
+    readyButtonText = "Ready";
+    saveButtonText = "Saving...";
+  } else if (orderStatus.Ready) {
+    readyEnabled = viewingCurPhase;
+    saveEnabled = false;
+    readyButtonText = "Unready";
+    saveButtonText = "Save";
+  } else if (orderStatus.Saved) {
+    readyEnabled = viewingCurPhase;
+    saveEnabled = ordersLength !== ordersSaved && viewingCurPhase;
+    readyButtonText = "Ready";
+    saveButtonText = "Save";
+  } else if (orderStatus.Completed) {
+    readyEnabled = ordersLength !== ordersSaved && viewingCurPhase;
+    saveEnabled = ordersLength !== ordersSaved && viewingCurPhase;
+    readyButtonText = "Ready";
+    saveButtonText = "Save";
+  } else {
+    readyEnabled = ordersLength !== ordersSaved && viewingCurPhase;
+    saveEnabled = viewingCurPhase;
+    readyButtonText = "Ready";
+    saveButtonText = "Save";
+  }
+
+  const doAnimateGlow =
+    saveEnabled && ordersLength !== ordersSaved && !currentOrderInProgress;
 
   const clickButton = (type: Move) => {
     // console.log("Entered save button click");
@@ -112,42 +151,27 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
             orderUpdates.push(orderUpdate);
           },
         );
-        const orderSubmission = {
+        const orderSubmission: OrderSubmission = {
           orderUpdates,
           context: JSON.stringify(contextVars.context),
           contextKey: contextVars.contextKey,
           queryParams: {},
+          userIntent: "saving",
         };
         if (type === Move.READY) {
-          orderSubmission.queryParams = gameState.ready
-            ? { notready: "on" }
-            : { ready: "on" };
+          if (orderStatus.Ready) {
+            orderSubmission.queryParams = { notready: "on" };
+            orderSubmission.userIntent = "unreadying";
+          } else {
+            orderSubmission.queryParams = { ready: "on" };
+            orderSubmission.userIntent = "readying";
+          }
         }
         // console.log({ orderSubmission });
         dispatch(saveOrders(orderSubmission));
       }
     }
-    if (type === Move.READY) {
-      toggleState(type);
-    }
   };
-
-  const ordersMetaValues = Object.values(ordersMeta);
-  const ordersLength = ordersMetaValues.length;
-  const ordersSaved = ordersMetaValues.reduce(
-    (acc, meta) => acc + +meta.saved,
-    0,
-  );
-  if (
-    (ordersLength === ordersSaved && gameState.save) ||
-    (ordersLength !== ordersSaved && !gameState.save)
-  ) {
-    toggleState(Move.SAVE);
-  }
-
-  const saveDisabled = gameState.ready || !gameState.save;
-  const doAnimateGlow =
-    !saveDisabled && ordersLength !== ordersSaved && !currentOrderInProgress;
 
   return (
     <Stack
@@ -157,28 +181,28 @@ const WDMoveControls: React.FC<WDMoveControlsProps> = function ({
     >
       <WDButton
         color="primary"
-        disabled={saveDisabled || !viewingCurPhase}
-        onClick={() => clickButton(Move.SAVE)}
+        disabled={!saveEnabled}
+        onClick={() => saveEnabled && clickButton(Move.SAVE)}
         sx={{
-          filter: saveDisabled
+          filter: !saveEnabled
             ? undefined
             : theme.palette.svg.filters.dropShadows[0],
         }}
         doAnimateGlow={doAnimateGlow}
       >
-        Save
+        {saveButtonText}
       </WDButton>
       <WDButton
         color="primary"
-        disabled={readyDisabled || !viewingCurPhase}
-        onClick={() => clickButton(Move.READY)}
+        disabled={!readyEnabled}
+        onClick={() => readyEnabled && clickButton(Move.READY)}
         sx={{
-          filter: readyDisabled
+          filter: !readyEnabled
             ? undefined
             : theme.palette.svg.filters.dropShadows[0],
         }}
       >
-        {gameState.ready ? "Unready" : "Ready"}
+        {readyButtonText}
       </WDButton>
     </Stack>
   );

--- a/beta-src/src/components/ui/WDPhaseUI.tsx
+++ b/beta-src/src/components/ui/WDPhaseUI.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { Box } from "@mui/material";
 import {
+  gameOrdersMeta,
   gameOverview,
   gameStatus,
   gameViewedPhase,
@@ -29,8 +30,16 @@ const WDPhaseUI: React.FC = function (): React.ReactElement {
     gameStatusData,
     viewedPhaseIdx,
   );
+  const ordersMeta = useAppSelector(gameOrdersMeta);
+  const ordersMetaValues = Object.values(ordersMeta);
+  const ordersLength = ordersMetaValues.length;
+  const ordersSaved = ordersMetaValues.reduce(
+    (acc, meta) => acc + +meta.saved,
+    0,
+  );
   const animateForwardGlow =
-    latestPhaseViewed < gameStatusData.phases.length - 1;
+    latestPhaseViewed < gameStatusData.phases.length - 1 ||
+    ordersSaved !== ordersLength;
 
   return (
     <Box

--- a/beta-src/src/components/ui/WDVoteButtons.tsx
+++ b/beta-src/src/components/ui/WDVoteButtons.tsx
@@ -9,11 +9,13 @@ import WDCheckmarkIcon from "./icons/WDCheckmarkIcon";
 
 interface voteProps {
   voteState: string[];
+  votingInProgress: { [key in Vote]: string | null };
   toggleVote: (vote: Vote) => void;
 }
 
 const WDVoteButtons: React.FC<voteProps> = function ({
   voteState,
+  votingInProgress,
   toggleVote,
 }): React.ReactElement {
   const [viewport] = useViewport();
@@ -26,10 +28,12 @@ const WDVoteButtons: React.FC<voteProps> = function ({
   const spacing = mobileLandscapeLayout ? 1 : 2;
   const commandButtons = Object.keys(Vote).map((vote) => {
     const status = voteState.includes(vote);
+    const disabled = votingInProgress[vote] !== null;
     return (
       <WDButton
         key={vote}
         sx={{ p: padding }}
+        disabled={disabled}
         color={status ? "secondary" : "primary"}
         onClick={() => toggleVote(Vote[vote])}
         startIcon={status ? <WDCheckmarkIcon /> : ""}

--- a/beta-src/src/enums/ApiRoute.ts
+++ b/beta-src/src/enums/ApiRoute.ts
@@ -5,7 +5,7 @@ enum ApiRoute {
   SEND_MESSAGE = "game/sendmessage",
   MESSAGES_SEEN = "game/messagesseen",
   GAME_OVERVIEW = "game/overview",
-  GAME_TOGGLEVOTE = "game/togglevote",
+  GAME_SETVOTE = "game/setvote",
 }
 
 export default ApiRoute;

--- a/beta-src/src/enums/Move.ts
+++ b/beta-src/src/enums/Move.ts
@@ -1,6 +1,0 @@
-enum Move {
-  SAVE = "save",
-  READY = "ready",
-}
-
-export default Move;

--- a/beta-src/src/interfaces/state/OrderSubmission.ts
+++ b/beta-src/src/interfaces/state/OrderSubmission.ts
@@ -1,9 +1,12 @@
 import { QueryParams } from "../../utils/api";
 import UpdateOrder from "./UpdateOrder";
 
+export type OrderSubmissionUserIntent = "saving" | "readying" | "unreadying"
+
 export default interface OrderSubmission {
   orderUpdates: UpdateOrder[];
   context: string;
   contextKey: string;
   queryParams?: QueryParams;
+  userIntent: OrderSubmissionUserIntent;
 }

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -244,6 +244,9 @@ const gameApiSlice = createSlice({
           m.status = MessageStatus.READ;
         });
     },
+    setNeedsGameOverview(state, action) {
+      state.needsGameOverview = action.payload;
+    },
     setNeedsGameData(state, action) {
       state.needsGameData = action.payload;
     },
@@ -327,6 +330,10 @@ const gameApiSlice = createSlice({
                 member.votes = newVotes;
               }
             });
+          } else {
+            // In any error case setting votes, try reloading everything so that we can
+            // attempt to resync with the server again.
+            state.needsGameOverview = true;
           }
         }
       })
@@ -335,11 +342,9 @@ const gameApiSlice = createSlice({
         state.error = action.error.message;
         const { vote } = action.meta.arg;
         state.votingInProgress = { ...state.votingInProgress, [vote]: null };
-        // In any error case saving orders, try reloading everything so that we can
+        // In any error case setting votes, try reloading everything so that we can
         // attempt to resync with the server again.
-        // store.dispatch(
-        //   fetchGameOverview({ gameID: state.overview.gameID.toString() }),
-        // );
+        state.needsGameOverview = true;
       })
       // Send message
       .addCase(sendMessage.fulfilled, (state, action) => {

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -152,6 +152,7 @@ const initialState: GameState = {
     Pause: null,
     Draw: null,
   },
+  needsGameOverview: false,
   needsGameData: false,
   legalOrders: {
     legalMoveDestsByUnitID: {},

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -147,6 +147,11 @@ const initialState: GameState = {
   outstandingOverviewRequests: false,
   outstandingMessageRequests: false,
   savingOrdersInProgress: null,
+  votingInProgress: {
+    Cancel: null,
+    Pause: null,
+    Draw: null,
+  },
   needsGameData: false,
   legalOrders: {
     legalMoveDestsByUnitID: {},

--- a/beta-src/src/state/game/initial-state.ts
+++ b/beta-src/src/state/game/initial-state.ts
@@ -146,6 +146,7 @@ const initialState: GameState = {
   },
   outstandingOverviewRequests: false,
   outstandingMessageRequests: false,
+  savingOrdersInProgress: null,
   needsGameData: false,
   legalOrders: {
     legalMoveDestsByUnitID: {},

--- a/beta-src/src/state/interfaces/GameState.ts
+++ b/beta-src/src/state/interfaces/GameState.ts
@@ -12,6 +12,7 @@ import ViewedPhaseState from "./ViewedPhaseState";
 import { LegalOrders } from "../../utils/state/gameApiSlice/extraReducers/fetchGameData/precomputeLegalOrders";
 import GameAlert from "./GameAlert";
 import { OrderSubmissionUserIntent } from "../../interfaces/state/OrderSubmission";
+import Vote from "../../enums/Vote";
 
 export type ApiStatus = "idle" | "loading" | "succeeded" | "failed";
 
@@ -30,6 +31,7 @@ export interface GameState {
   outstandingOverviewRequests: boolean; // Stateful, restricts querying api for overview
   outstandingMessageRequests: boolean; // Stateful, restricts querying api for messages
   savingOrdersInProgress: OrderSubmissionUserIntent | null; // Stateful, non-null when we have an active request to save orders.
+  votingInProgress: { [key in Vote] : string | null }; // Stateful, non-null "Yes" or "No" values indicate we have an active vote query to set vote to "Yes" or to "No".
   needsGameData: boolean; // Stateful, determines when game data has changed and needs refresh
   order: OrderState;
   legalOrders: LegalOrders; // Computed as a function of GameOverviewResponse, GameDataResponse, GameStateMaps

--- a/beta-src/src/state/interfaces/GameState.ts
+++ b/beta-src/src/state/interfaces/GameState.ts
@@ -32,6 +32,7 @@ export interface GameState {
   outstandingMessageRequests: boolean; // Stateful, restricts querying api for messages
   savingOrdersInProgress: OrderSubmissionUserIntent | null; // Stateful, non-null when we have an active request to save orders.
   votingInProgress: { [key in Vote] : string | null }; // Stateful, non-null "Yes" or "No" values indicate we have an active vote query to set vote to "Yes" or to "No".
+  needsGameOverview: boolean; // Stateful, determines when game overview needs urgent refresh
   needsGameData: boolean; // Stateful, determines when game data has changed and needs refresh
   order: OrderState;
   legalOrders: LegalOrders; // Computed as a function of GameOverviewResponse, GameDataResponse, GameStateMaps

--- a/beta-src/src/state/interfaces/GameState.ts
+++ b/beta-src/src/state/interfaces/GameState.ts
@@ -11,6 +11,7 @@ import TerritoriesMeta from "./TerritoriesState";
 import ViewedPhaseState from "./ViewedPhaseState";
 import { LegalOrders } from "../../utils/state/gameApiSlice/extraReducers/fetchGameData/precomputeLegalOrders";
 import GameAlert from "./GameAlert";
+import { OrderSubmissionUserIntent } from "../../interfaces/state/OrderSubmission";
 
 export type ApiStatus = "idle" | "loading" | "succeeded" | "failed";
 
@@ -28,6 +29,7 @@ export interface GameState {
   messages: GameMessages;
   outstandingOverviewRequests: boolean; // Stateful, restricts querying api for overview
   outstandingMessageRequests: boolean; // Stateful, restricts querying api for messages
+  savingOrdersInProgress: OrderSubmissionUserIntent | null; // Stateful, non-null when we have an active request to save orders.
   needsGameData: boolean; // Stateful, determines when game data has changed and needs refresh
   order: OrderState;
   legalOrders: LegalOrders; // Computed as a function of GameOverviewResponse, GameDataResponse, GameStateMaps

--- a/beta-src/src/types/MoveStatus.ts
+++ b/beta-src/src/types/MoveStatus.ts
@@ -1,7 +1,0 @@
-import Move from "../enums/Move";
-
-type MoveStatus = {
-  [key in Move]: boolean;
-};
-
-export default MoveStatus;

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
@@ -60,9 +60,7 @@ export function saveRejectOrdersCommon(state: GameState, action): void {
       }
       // In any error case saving orders, try reloading everything so that we can
       // attempt to resync with the server again.
-      // store.dispatch(
-      //   fetchGameOverview({ gameID: state.overview.gameID.toString() }),
-      // );
+      state.needsGameOverview = true;
       state.needsGameData = true;
     }
   } else {
@@ -72,9 +70,7 @@ export function saveRejectOrdersCommon(state: GameState, action): void {
     );
     // In any error case, try reloading everything so that we can attempt to resync
     // with the server again.
-    // store.dispatch(
-    //   fetchGameOverview({ gameID: state.overview.gameID.toString() }),
-    // );
+    state.needsGameOverview = true;
     state.needsGameData = true;
   }
 }

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
@@ -1,9 +1,22 @@
 import SavedOrdersConfirmation from "../../../../../interfaces/state/SavedOrdersConfirmation";
+import {
+  fetchGameOverview,
+  gameApiSliceActions,
+} from "../../../../../state/game/game-api-slice";
+import { useAppDispatch } from "../../../../../state/hooks";
 import { setAlert } from "../../../../../state/interfaces/GameAlert";
 import getOrderStates from "../../../getOrderStates";
+import { GameState } from "../../../../../state/interfaces/GameState";
+import OrderSubmission from "../../../../../interfaces/state/OrderSubmission";
 
 /* eslint-disable no-param-reassign */
-export default function saveOrdersFulfilled(state, action): void {
+export function saveOrdersPending(state: GameState, action): void {
+  const queryParams = action.meta.arg as OrderSubmission;
+  state.savingOrdersInProgress = queryParams.userIntent;
+}
+
+export function saveOrdersFulfilled(state: GameState, action): void {
+  state.savingOrdersInProgress = null;
   if (action.payload) {
     const {
       invalid,
@@ -18,12 +31,15 @@ export default function saveOrdersFulfilled(state, action): void {
         contextKey: newContextKey,
       };
       const orderStates = getOrderStates(newContext.orderStatus);
-      state.overview.user.member.orderStatus = {
-        Completed: orderStates.Completed,
-        Ready: orderStates.Ready,
-        None: orderStates.None,
-        Saved: orderStates.Saved,
-      };
+      if (state.overview.user) {
+        state.overview.user.member.orderStatus = {
+          Completed: orderStates.Completed,
+          Ready: orderStates.Ready,
+          None: orderStates.None,
+          Saved: orderStates.Saved,
+          Hidden: false,
+        };
+      }
     }
     // console.log({ returnOrders: orders });
     Object.entries(orders).forEach(([id, value]) => {
@@ -42,6 +58,27 @@ export default function saveOrdersFulfilled(state, action): void {
           `Unknown error saving orders, server indicated that API call was invalid`,
         );
       }
+      // In any error case saving orders, try reloading everything so that we can
+      // attempt to resync with the server again.
+      // store.dispatch(
+      //   fetchGameOverview({ gameID: state.overview.gameID.toString() }),
+      // );
+      state.needsGameData = true;
     }
+  } else {
+    setAlert(
+      state.alert,
+      `Unknown error saving orders, server indicated that API call was invalid`,
+    );
+    // In any error case, try reloading everything so that we can attempt to resync
+    // with the server again.
+    // store.dispatch(
+    //   fetchGameOverview({ gameID: state.overview.gameID.toString() }),
+    // );
+    state.needsGameData = true;
   }
+}
+
+export function saveOrdersRejected(state, action): void {
+  saveOrdersFulfilled(state, action);
 }

--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/saveOrders/fulfilled.ts
@@ -15,7 +15,7 @@ export function saveOrdersPending(state: GameState, action): void {
   state.savingOrdersInProgress = queryParams.userIntent;
 }
 
-export function saveOrdersFulfilled(state: GameState, action): void {
+export function saveRejectOrdersCommon(state: GameState, action): void {
   state.savingOrdersInProgress = null;
   if (action.payload) {
     const {
@@ -79,6 +79,12 @@ export function saveOrdersFulfilled(state: GameState, action): void {
   }
 }
 
+export function saveOrdersFulfilled(state: GameState, action): void {
+  state.apiStatus = "succeeded";
+  saveRejectOrdersCommon(state, action);
+}
+
 export function saveOrdersRejected(state, action): void {
-  saveOrdersFulfilled(state, action);
+  state.apiStatus = "failed";
+  saveRejectOrdersCommon(state, action);
 }

--- a/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
@@ -18,7 +18,6 @@ import { TerritoryMeta } from "../../../../state/interfaces/TerritoriesState";
 import { getTargetXYWH } from "../../../map/drawArrowFunctional";
 import invalidClick from "../../../map/invalidClick";
 import getAvailableOrder from "../../getAvailableOrder";
-import getOrderStates from "../../getOrderStates";
 import resetOrder from "../../resetOrder";
 import startNewOrder from "../../startNewOrder";
 import updateOrder from "../../updateOrder";


### PR DESCRIPTION
This is an attempt to add "saving/readying' states for saving and readying buttons, and similarly for the voting buttons.

On all of them, we track whether a query is live, and if so, the button is disabled.

For voting, we update the API to be in terms of setting a value rather than toggling it - setting a value is much more robust than toggling in case the client and server get out of sync, or a request gets sent more than once, etc. We also remove the client-side rapid updating of the voting status - the only way the voting status gets updated is once we get the response back from the server about what the new votes are.

The rendering of the fulloverlay panel is extremely poor right now - there is noticeable lag when clicking on the voting buttons due to react rendering time and DOM rendering time. That's probably something we'll leave for more dedidcated UI people.