### PR TITLE
WDIP-34: Unsaved flicker

### DIFF
--- a/beta-src/src/components/controllers/WDUnitController.tsx
+++ b/beta-src/src/components/controllers/WDUnitController.tsx
@@ -10,7 +10,7 @@ import WDArmyIcon, {
 } from "../ui/units/WDArmyIcon";
 import { Unit } from "../../utils/map/getUnits";
 import UIState from "../../enums/UIState";
-import { makeSVGDrawAsUnsavedAnimateElement } from "../../utils/map/drawArrowFunctional";
+import { makeSVGDrawAsUnsavedAnimateElementGentle } from "../../utils/map/drawArrowFunctional";
 
 interface UnitControllerProps {
   unit: Unit;
@@ -53,7 +53,7 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
       {unit.unit.type === "Army" && (
         <WDArmyIcon iconState={unitState} country={unit.country} />
       )}
-      {unit.drawAsUnsaved && makeSVGDrawAsUnsavedAnimateElement()}
+      {unit.drawAsUnsaved && makeSVGDrawAsUnsavedAnimateElementGentle()}
     </g>
   );
 };

--- a/beta-src/src/components/controllers/WDUnitController.tsx
+++ b/beta-src/src/components/controllers/WDUnitController.tsx
@@ -1,8 +1,5 @@
 import * as React from "react";
-import { GameIconProps } from "../../interfaces/Icons";
 import debounce from "../../utils/debounce";
-import { useAppDispatch, useAppSelector } from "../../state/hooks";
-import { gameApiSliceActions } from "../../state/game/game-api-slice";
 import WDFleetIcon, {
   FLEET_RAW_ICON_WIDTH,
   FLEET_RAW_ICON_HEIGHT,
@@ -11,26 +8,27 @@ import WDArmyIcon, {
   ARMY_RAW_ICON_WIDTH,
   ARMY_RAW_ICON_HEIGHT,
 } from "../ui/units/WDArmyIcon";
+import { Unit } from "../../utils/map/getUnits";
+import UIState from "../../enums/UIState";
+import { makeSVGDrawAsUnsavedAnimateElement } from "../../utils/map/drawArrowFunctional";
 
 interface UnitControllerProps {
-  meta: GameIconProps["meta"];
-  type: GameIconProps["type"];
-  iconState: GameIconProps["iconState"];
+  unit: Unit;
+  unitState: UIState;
   unitWidth: number;
   unitHeight: number;
 }
 
 const WDUnitController: React.FC<UnitControllerProps> = function ({
-  meta,
-  type,
-  iconState,
+  unit,
+  unitState,
   unitWidth,
   unitHeight,
 }): React.ReactElement {
   const iconWidth =
-    type === "Fleet" ? FLEET_RAW_ICON_WIDTH : ARMY_RAW_ICON_WIDTH;
+    unit.unit.type === "Fleet" ? FLEET_RAW_ICON_WIDTH : ARMY_RAW_ICON_WIDTH;
   const iconHeight =
-    type === "Fleet" ? FLEET_RAW_ICON_HEIGHT : ARMY_RAW_ICON_HEIGHT;
+    unit.unit.type === "Fleet" ? FLEET_RAW_ICON_HEIGHT : ARMY_RAW_ICON_HEIGHT;
 
   // The icons expect that 0,0 is the upper left corner of the unit, whereas this WDUnitController
   // svg element is expected to be positioned such that 0,0 is the center of the
@@ -49,12 +47,13 @@ const WDUnitController: React.FC<UnitControllerProps> = function ({
       style={{ pointerEvents: "none", overflow: "visible" }}
       transform={transform}
     >
-      {type === "Fleet" && (
-        <WDFleetIcon iconState={iconState} country={meta.country} />
+      {unit.unit.type === "Fleet" && (
+        <WDFleetIcon iconState={unitState} country={unit.country} />
       )}
-      {type === "Army" && (
-        <WDArmyIcon iconState={iconState} country={meta.country} />
+      {unit.unit.type === "Army" && (
+        <WDArmyIcon iconState={unitState} country={unit.country} />
       )}
+      {unit.drawAsUnsaved && makeSVGDrawAsUnsavedAnimateElement()}
     </g>
   );
 };

--- a/beta-src/src/components/map/components/WDArrowContainer.tsx
+++ b/beta-src/src/components/map/components/WDArrowContainer.tsx
@@ -14,6 +14,7 @@ import ArrowColor from "../../../enums/ArrowColor";
 import drawArrowFunctional, {
   getTargetXYWH,
   getArrowX1Y1X2Y2,
+  makeSVGDrawAsUnsavedAnimateElement,
 } from "../../../utils/map/drawArrowFunctional";
 import TerritoryMap from "../../../data/map/variants/classic/TerritoryMap";
 import { APITerritories } from "../../../state/interfaces/GameDataResponse";
@@ -61,6 +62,7 @@ function accumulateMoveOrderArrows(
           fromTerr,
           "territory",
           toTerr,
+          order.drawAsUnsaved,
         ),
       );
       // console.log("ARROW");
@@ -150,6 +152,7 @@ function accumulateSupportHoldOrderArrows(
           supporterTerr,
           "unit",
           supporteeTerr,
+          order.drawAsUnsaved,
           offsetArrowSourcePixels,
         ),
       );
@@ -217,6 +220,7 @@ function accumulateSupportMoveOrderArrows(
             supporterTerr,
             "arrow",
             getArrowX1Y1X2Y2("unit", supporteeTerr, "territory", toTerr),
+            order.drawAsUnsaved,
           ),
         );
       } else {
@@ -230,6 +234,7 @@ function accumulateSupportMoveOrderArrows(
             supporterTerr,
             "arrow",
             getArrowX1Y1X2Y2("unit", supporteeTerr, "territory", toTerr),
+            order.drawAsUnsaved,
           ),
         );
         // Also draw a ghosty arrow of what we're trying to support.
@@ -244,6 +249,7 @@ function accumulateSupportMoveOrderArrows(
               supporteeTerr,
               "territory",
               toTerr,
+              order.drawAsUnsaved,
             ),
           );
         }
@@ -295,6 +301,7 @@ function accumulateConvoyOrderArrows(
           convoyerTerr,
           "arrow",
           getArrowX1Y1X2Y2("unit", convoyeeTerr, "territory", toTerr),
+          order.drawAsUnsaved,
         ),
       );
       if (!isCoordinated) {
@@ -310,6 +317,7 @@ function accumulateConvoyOrderArrows(
               convoyeeTerr,
               "territory",
               toTerr,
+              order.drawAsUnsaved,
             ),
           );
         }
@@ -339,6 +347,7 @@ function accumulateRetreatArrows(
           fromTerr,
           "territory",
           toTerr,
+          order.drawAsUnsaved,
         ),
       );
     });
@@ -365,6 +374,7 @@ function accumulateDislodgerArrows(
           fromTerr,
           "dislodger",
           toTerr,
+          false,
         ),
       );
     });
@@ -391,7 +401,9 @@ function accumulateBuildCircles(
           fill="none"
           stroke="rgb(0,150,0)"
           strokeWidth={0.05 * (w + h)}
-        />,
+        >
+          {unit.drawAsUnsaved && makeSVGDrawAsUnsavedAnimateElement()}
+        </circle>,
       );
     });
 }
@@ -416,7 +428,9 @@ function accumulateDisbandMarks(
           y2={y1 + MARKSIZE}
           stroke="red"
           strokeWidth={4}
-        />,
+        >
+          {unit.drawAsUnsaved && makeSVGDrawAsUnsavedAnimateElement()}
+        </line>,
       );
       arrows.push(
         <line
@@ -427,7 +441,9 @@ function accumulateDisbandMarks(
           y2={y1 + MARKSIZE}
           stroke="red"
           strokeWidth={4}
-        />,
+        >
+          {unit.drawAsUnsaved && makeSVGDrawAsUnsavedAnimateElement()}
+        </line>,
       );
     });
 }
@@ -474,6 +490,7 @@ function accumulateStandoffMarks(
           src,
           "territory",
           dst,
+          false,
         ),
       );
     });

--- a/beta-src/src/components/map/components/WDProvinceOverlay.tsx
+++ b/beta-src/src/components/map/components/WDProvinceOverlay.tsx
@@ -60,13 +60,7 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
           break;
       }
       const wdUnit = (
-        <WDUnit
-          id={`${province}-unit`}
-          country={unit.country}
-          meta={unit}
-          type={unit.unit.type as UnitType}
-          iconState={unitState}
-        />
+        <WDUnit id={`${province}-unit`} unit={unit} unitState={unitState} />
       );
       if (unit.drawMode === UnitDrawMode.DISLODGING) {
         unitFCsDislodging[unit.mappedTerritory.unitSlotName] = wdUnit;

--- a/beta-src/src/components/map/components/WDProvinceOverlay.tsx
+++ b/beta-src/src/components/map/components/WDProvinceOverlay.tsx
@@ -70,13 +70,13 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
     });
 
   return (
-    <svg
+    <g
       height={provinceMapData.height}
       id={`${province}-province-overlay`}
-      viewBox={provinceMapData.viewBox}
       width={provinceMapData.width}
       x={provinceMapData.x}
       y={provinceMapData.y}
+      transform={`translate(${provinceMapData.x} ${provinceMapData.y})`}
       overflow="visible"
     >
       {provinceMapData.unitSlots
@@ -103,7 +103,7 @@ const WDProvinceOverlay: React.FC<WDProvinceOverlayProps> = function ({
             </WDUnitSlot>
           );
         })}
-    </svg>
+    </g>
   );
 };
 

--- a/beta-src/src/components/map/components/WDUnitSlot.tsx
+++ b/beta-src/src/components/map/components/WDUnitSlot.tsx
@@ -13,15 +13,16 @@ const WDUnitSlot: React.FC<WDUnitSlotProps> = function ({
   y,
 }): React.ReactElement {
   return (
-    <svg
+    <g
       className="unit-slot"
       id={`${name}-unit-slot`}
       style={{ overflow: "visible" }}
       x={x}
       y={y}
+      transform={`translate(${x} ${y})`}
     >
       {children}
-    </svg>
+    </g>
   );
 };
 

--- a/beta-src/src/components/ui/WDButton.tsx
+++ b/beta-src/src/components/ui/WDButton.tsx
@@ -30,8 +30,7 @@ const WDButton: React.FC<WDButtonProps> = function ({
       startIcon={startIcon}
       variant="contained"
       style={{
-        animation:
-          doAnimateGlow && !disabled ? "glowing 1.5s ease infinite" : "",
+        animation: doAnimateGlow && !disabled ? "glowing 1s infinite" : "",
         pointerEvents: "auto",
       }}
     >

--- a/beta-src/src/components/ui/WDMain.tsx
+++ b/beta-src/src/components/ui/WDMain.tsx
@@ -85,6 +85,7 @@ const WDMain: React.FC = function (): React.ReactElement {
         let toTerrID = 0;
         let type: string | null = "";
         let viaConvoy;
+        const drawAsUnsaved = !orderMeta.saved;
 
         let { originalOrder } = orderMeta;
         if (!originalOrder) {
@@ -163,6 +164,7 @@ const WDMain: React.FC = function (): React.ReactElement {
           type,
           unitType,
           viaConvoy,
+          drawAsUnsaved,
         };
         ordersHistorical.push(orderHistorical);
       });

--- a/beta-src/src/components/ui/units/WDUnit.tsx
+++ b/beta-src/src/components/ui/units/WDUnit.tsx
@@ -20,7 +20,7 @@ const WDUnit: React.FC<WDUnitProps> = function ({
 }): React.ReactElement {
   const theme = useTheme();
   return (
-    <svg
+    <g
       filter={theme.palette.svg.filters.dropShadows[1]}
       height={UNIT_HEIGHT}
       id={id}
@@ -33,7 +33,7 @@ const WDUnit: React.FC<WDUnitProps> = function ({
         unitWidth={UNIT_WIDTH}
         unitHeight={UNIT_HEIGHT}
       />
-    </svg>
+    </g>
   );
 };
 

--- a/beta-src/src/components/ui/units/WDUnit.tsx
+++ b/beta-src/src/components/ui/units/WDUnit.tsx
@@ -1,20 +1,22 @@
 import * as React from "react";
 import { useTheme } from "@mui/material/styles";
-import UIState from "../../../enums/UIState";
 import WDUnitController from "../../controllers/WDUnitController";
-import { GameIconProps } from "../../../interfaces/Icons";
-import WDArmyIcon from "./WDArmyIcon";
-import { useAppSelector } from "../../../state/hooks";
+import { Unit } from "../../../utils/map/getUnits";
+import UIState from "../../../enums/UIState";
 
 export const UNIT_HEIGHT = 75;
 export const UNIT_WIDTH = 75;
 
-const WDUnit: React.FC<GameIconProps> = function ({
-  id = undefined,
-  meta,
-  viewBox,
-  type,
-  iconState,
+interface WDUnitProps {
+  id: string | undefined;
+  unit: Unit;
+  unitState: UIState;
+}
+
+const WDUnit: React.FC<WDUnitProps> = function ({
+  id,
+  unit,
+  unitState,
 }): React.ReactElement {
   const theme = useTheme();
   return (
@@ -23,13 +25,11 @@ const WDUnit: React.FC<GameIconProps> = function ({
       height={UNIT_HEIGHT}
       id={id}
       width={UNIT_WIDTH}
-      viewBox={viewBox}
       style={{ overflow: "visible" }}
     >
       <WDUnitController
-        meta={meta}
-        type={type}
-        iconState={iconState}
+        unit={unit}
+        unitState={unitState}
         unitWidth={UNIT_WIDTH}
         unitHeight={UNIT_HEIGHT}
       />

--- a/beta-src/src/interfaces/Icons.ts
+++ b/beta-src/src/interfaces/Icons.ts
@@ -1,7 +1,5 @@
 import Country from "../enums/Country";
 import UIState from "../enums/UIState";
-import UnitType from "../types/UnitType";
-import { UnitMeta } from "./map/UnitMeta";
 
 export interface NavIconProps {
   iconState?: UIState.ACTIVE | UIState.INACTIVE;
@@ -10,13 +8,4 @@ export interface NavIconProps {
 export interface IconProps {
   country: Country;
   iconState?: UIState;
-}
-
-export interface GameIconProps extends IconProps {
-  height?: number;
-  id?: string;
-  viewBox?: string;
-  width?: number;
-  meta: UnitMeta;
-  type: UnitType;
 }

--- a/beta-src/src/interfaces/index.ts
+++ b/beta-src/src/interfaces/index.ts
@@ -5,5 +5,4 @@ export * from "./map/ProvinceMapData";
 export * from "./map/Label";
 export * from "./map/TextureData";
 export * from "./state/MemberData";
-export * from "./map/UnitMeta";
 export * from "./state/UpdateOrder";

--- a/beta-src/src/interfaces/map/UnitMeta.ts
+++ b/beta-src/src/interfaces/map/UnitMeta.ts
@@ -1,9 +1,0 @@
-import { MTerritory } from "../../data/map/variants/classic/TerritoryMap";
-import Country from "../../enums/Country";
-import { IUnit } from "../../models/Interfaces";
-
-export interface UnitMeta {
-  mappedTerritory: MTerritory;
-  unit: IUnit;
-  country: Country;
-}

--- a/beta-src/src/models/Interfaces.ts
+++ b/beta-src/src/models/Interfaces.ts
@@ -117,6 +117,9 @@ export interface IOrderDataHistorical {
   type: string;
   unitType: string;
   viaConvoy: string;
+  // drawAsUnsaved is only present and set to true locally / internally when we 
+  // want an order to be drawn in a way that indicates it is unsaved.
+  drawAsUnsaved?: boolean; 
 }
 
 export interface IPhaseDataHistorical {

--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -156,9 +156,22 @@ export function makeSVGDrawAsUnsavedAnimateElement(): React.ReactElement {
   return (
     <animate
       attributeName="opacity"
-      values="1.0;1.0;0.25;0.25"
-      keyTimes="0; 0.5; 0.5; 1.0"
-      dur="1s"
+      values="1.0;0.8;0.25;0.8;1.0"
+      keyTimes="0; 0.25; 0.5; 0.75; 1.0"
+      dur="1.0s"
+      repeatCount="indefinite"
+    />
+  );
+}
+// Gentler blinking, for things that are larger and therefore don't need to blink
+// quite as hard as arrows do to be equally visually attention-drawing.
+export function makeSVGDrawAsUnsavedAnimateElementGentle(): React.ReactElement {
+  return (
+    <animate
+      attributeName="opacity"
+      values="1.0;0.9;0.5;0.9;1.0"
+      keyTimes="0; 0.25; 0.5; 0.75; 1.0"
+      dur="1.0s"
       repeatCount="indefinite"
     />
   );

--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -156,8 +156,9 @@ export function makeSVGDrawAsUnsavedAnimateElement(): React.ReactElement {
   return (
     <animate
       attributeName="opacity"
-      values="1.0;0.8;0.3;0.8;1.0"
-      dur="0.8s"
+      values="1.0;1.0;0.25;0.25"
+      keyTimes="0; 0.5; 0.5; 1.0"
+      dur="1s"
       repeatCount="indefinite"
     />
   );

--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -156,7 +156,7 @@ export function makeSVGDrawAsUnsavedAnimateElement(): React.ReactElement {
   return (
     <animate
       attributeName="opacity"
-      values="1.0;0.5;1.0"
+      values="1.0;0.8;0.3;0.8;1.0"
       dur="0.8s"
       repeatCount="indefinite"
     />

--- a/beta-src/src/utils/map/drawArrowFunctional.tsx
+++ b/beta-src/src/utils/map/drawArrowFunctional.tsx
@@ -152,6 +152,17 @@ export function getArrowX1Y1X2Y2(
   return [x1, y1, x2, y2];
 }
 
+export function makeSVGDrawAsUnsavedAnimateElement(): React.ReactElement {
+  return (
+    <animate
+      attributeName="opacity"
+      values="1.0;0.5;1.0"
+      dur="0.8s"
+      repeatCount="indefinite"
+    />
+  );
+}
+
 // See getTargetXYWH for a description of the possible types and identifiers.
 export default function drawArrowFunctional(
   arrowType: ArrowType,
@@ -160,6 +171,7 @@ export default function drawArrowFunctional(
   sourceIdentifier: Territory | [number, number, number, number],
   receiverType: "territory" | "unit" | "arrow" | "dislodger",
   receiverIdentifier: Territory | [number, number, number, number],
+  drawAsUnsaved: boolean | undefined = false,
   offsetArrowSourcePixels = 0.0,
 ): React.ReactElement {
   // console.log(
@@ -231,6 +243,8 @@ export default function drawArrowFunctional(
       stroke={webDiplomacyTheme.palette.arrowColors[arrowColor].main}
       strokeWidth={strokeWidth}
       strokeDasharray={strokeDasharray}
-    />
+    >
+      {drawAsUnsaved && makeSVGDrawAsUnsavedAnimateElement()}
+    </line>
   );
 }

--- a/beta-src/src/utils/map/getUnits.ts
+++ b/beta-src/src/utils/map/getUnits.ts
@@ -138,9 +138,12 @@ export function getUnitsLive(
             territoryStatusesByProvID[unitProvID].unitID !== null &&
             territoryStatusesByProvID[unitProvID].unitID !== unit.id;
 
+          if (ordersMetaByTerrID[unit.terrID]?.update?.type) {
+            drawAsUnsaved = !ordersMetaByTerrID[unit.terrID].saved;
+          }
+
           if (ordersMetaByTerrID[unit.terrID]?.update?.type === "Hold") {
             drawMode = UnitDrawMode.HOLD;
-            drawAsUnsaved = !ordersMetaByTerrID[unit.terrID].saved;
           } else if (
             isRetreat &&
             // Webdip API might specify disbands in terms of province ID.
@@ -149,7 +152,6 @@ export function getUnitsLive(
               ordersMetaByTerrID[unitProvID]?.update?.type === "Disband")
           ) {
             drawMode = UnitDrawMode.DISBANDED;
-            drawAsUnsaved = !ordersMetaByTerrID[unit.terrID].saved;
           } else if (
             // Webdip API specifies destroys in terms of province ID!!
             // So also check the province ID, i.e. the ID of the root territory.
@@ -157,7 +159,6 @@ export function getUnitsLive(
             ordersMetaByTerrID[unitProvID]?.update?.type === "Destroy"
           ) {
             drawMode = UnitDrawMode.DISBANDED;
-            drawAsUnsaved = !ordersMetaByTerrID[unit.terrID].saved;
           } else if (isRetreat) {
             drawMode = UnitDrawMode.DISLODGED;
           } else if (unitCountByProvID[unitProvID] >= 2) {


### PR DESCRIPTION
Make units and arrows animatedly flicker while unsaved.
It's subtle in some ways, but maybe playtesting will show whether it's enough to reduce the frequency of forgetting to save?

What do you think?

Also in the process, do a bit of minor code cleanup and delete an interface that doesn't have any purpose and was used only in one place anyways

https://user-images.githubusercontent.com/11942395/175698133-0be4b1e3-2d25-4ccb-8897-0da6930e1496.mp4

.