### PR TITLE
Don't give an exception if vote response is empty string (ie no votes)

### DIFF
--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -339,22 +339,15 @@ const gameApiSlice = createSlice({
       .addCase(setVoteStatus.fulfilled, (state, action) => {
         const { vote } = action.meta.arg;
         state.votingInProgress = { ...state.votingInProgress, [vote]: null };
-        if (action.payload) {
-          handlePostSucceeded(state);
-          if (state.overview.user) {
-            const newVotes = action.payload.split(",").filter((s) => !!s);
-            state.overview.user.member.votes = newVotes;
-            state.overview.members.forEach((member) => {
-              if (member.countryID === state.overview.user?.member.countryID) {
-                member.votes = newVotes;
-              }
-            });
-          }
-        } else {
-          handlePostFailed(
-            state,
-            "Error sending vote, network connection issue",
-          );
+        handlePostSucceeded(state);
+        if (state.overview.user) {
+          const newVotes = action.payload.split(",").filter((s) => !!s);
+          state.overview.user.member.votes = newVotes;
+          state.overview.members.forEach((member) => {
+            if (member.countryID === state.overview.user?.member.countryID) {
+              member.votes = newVotes;
+            }
+          });
         }
       })
       .addCase(setVoteStatus.rejected, (state, action) => {


### PR DESCRIPTION
This guard for setVote network failure is wrong. Payload will be an empty string if there are no votes submitted. So deleted this guard.

You will still properly handle a network error, which should return `setVoteStatus.rejected`.


![image](https://user-images.githubusercontent.com/5702157/175783841-8e57c000-e847-4c07-9ab9-857f7d2ae327.png)
