### PR TITLE
WDIP-26: WIP on processing votes.

### DIFF
--- a/api.php
+++ b/api.php
@@ -338,7 +338,6 @@ class ToggleVote extends ApiEntry {
 		if (!empty(Config::$apiConfig['restrictToGameIDs']) && !in_array($gameID, Config::$apiConfig['restrictToGameIDs']))
 			throw new ClientForbiddenException('Game ID is not in list of gameIDs where API usage is permitted.');
 
-		$game = 
 		$currentVotes = $DB->sql_hash("SELECT votes FROM wD_Members WHERE gameID = ".$gameID." AND countryID = ".$countryID." AND userID = ".$userID);
 		$currentVotes = $currentVotes['votes'];
 
@@ -369,6 +368,8 @@ class ToggleVote extends ApiEntry {
 		}
 		$DB->sql_put("UPDATE wD_Members SET votes = '".$newVotes."' WHERE gameID = ".$gameID." AND userID = ".$userID." AND countryID = ".$countryID);
 		$DB->sql_put("COMMIT");
+		$Game = $this->getAssociatedGame();
+		$Game->Members->processVotes();
 		return $newVotes;
 	}
 }
@@ -397,7 +398,6 @@ class SetVote extends ApiEntry {
 		if (!empty(Config::$apiConfig['restrictToGameIDs']) && !in_array($gameID, Config::$apiConfig['restrictToGameIDs']))
 			throw new ClientForbiddenException('Game ID is not in list of gameIDs where API usage is permitted.');
 
-		$game = 
 		$currentVotes = $DB->sql_hash("SELECT votes FROM wD_Members WHERE gameID = ".$gameID." AND countryID = ".$countryID." AND userID = ".$userID);
 		$currentVotes = $currentVotes['votes'];
 
@@ -431,6 +431,8 @@ class SetVote extends ApiEntry {
 		}
 		$DB->sql_put("UPDATE wD_Members SET votes = '".$newVotes."' WHERE gameID = ".$gameID." AND userID = ".$userID." AND countryID = ".$countryID);
 		$DB->sql_put("COMMIT");
+		$Game = $this->getAssociatedGame();
+		$Game->Members->processVotes();
 		return $newVotes;
 	}
 }

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -128,6 +128,7 @@ export const setVoteStatus = createAsyncThunk(
     vote: string;
     voteOn: string;
   }) => {
+    console.log("Submitting vote");
     const { data } = await postGameApiRequest(
       ApiRoute.GAME_SETVOTE,
       queryParams,
@@ -332,11 +333,13 @@ const gameApiSlice = createSlice({
       .addCase(saveOrders.rejected, saveOrdersRejected)
       // setVoteStatus
       .addCase(setVoteStatus.pending, (state, action) => {
+        console.log("Vote pending");
         state.apiStatus = "loading";
         const { vote, voteOn } = action.meta.arg;
         state.votingInProgress = { ...state.votingInProgress, [vote]: voteOn };
       })
       .addCase(setVoteStatus.fulfilled, (state, action) => {
+        console.log({ action });
         const { vote } = action.meta.arg;
         state.votingInProgress = { ...state.votingInProgress, [vote]: null };
         if (action.payload) {

--- a/board.php
+++ b/board.php
@@ -173,38 +173,8 @@ if( isset($Member) && $Member->status == 'Playing' && $Game->phase!='Finished' )
 	}
 	else
 	{
-		if( $Game->Members->votesPassed() && $Game->phase!='Finished' )
-		{
-			$MC->append('processHint',','.$Game->id);
-
-			$DB->get_lock('gamemaster',1);
-
-			$DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$Game->id);
-			$DB->sql_put("COMMIT");
-
-			require_once(l_r('gamemaster/game.php'));
-			$Game = $Game->Variant->processGame($Game->id);
-			try
-			{
-				$Game->applyVotes(); // Will requery votesPassed()
-				$DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$Game->id);
-				$DB->sql_put("COMMIT");
-			}
-			catch(Exception $e)
-			{
-				if( $e->getMessage() == "Abandoned" || $e->getMessage() == "Cancelled" )
-				{
-					assert('$Game->phase=="Pre-game" || $e->getMessage() == "Cancelled"');
-					$DB->sql_put("COMMIT");
-					libHTML::notice(l_t('Cancelled'), l_t("Game was cancelled or didn't have enough players to start."));
-				}
-				else
-					$DB->sql_put("ROLLBACK");
-
-				throw $e;
-			}
-		}
-		else if( $Game->needsProcess() )
+		$Game->Members->processVotes();
+		if( $Game->needsProcess() )
 		{
 			$MC->append('processHint',','.$Game->id);
 		}

--- a/objects/members.php
+++ b/objects/members.php
@@ -159,6 +159,42 @@ class Members
 		return $votes;
 	}
 
+	function processVotes() {
+		global $MC, $DB;
+		$Game = $this->Game;
+		if( $Game->Members->votesPassed() && $Game->phase!='Finished' )
+		{
+			$MC->append('processHint',','.$Game->id);
+
+			$DB->get_lock('gamemaster',1);
+
+			$DB->sql_put("UPDATE wD_Games SET attempts=attempts+1 WHERE id=".$Game->id);
+			$DB->sql_put("COMMIT");
+
+			require_once(l_r('gamemaster/game.php'));
+			$Game = $Game->Variant->processGame($Game->id);
+			try
+			{
+				$Game->applyVotes(); // Will requery votesPassed()
+				$DB->sql_put("UPDATE wD_Games SET attempts=0 WHERE id=".$Game->id);
+				$DB->sql_put("COMMIT");
+			}
+			catch(Exception $e)
+			{
+				if( $e->getMessage() == "Abandoned" || $e->getMessage() == "Cancelled" )
+				{
+					assert($Game->phase=="Pre-game" || $e->getMessage() == "Cancelled");
+					$DB->sql_put("COMMIT");
+					// libHTML::notice(l_t('Cancelled'), l_t("Game was cancelled or didn't have enough players to start."));
+				}
+				else
+					$DB->sql_put("ROLLBACK");
+
+				throw $e;
+			}
+		}
+	}
+
 	function isReady()
 	{
 		foreach($this->ByStatus['Playing'] as $Member)


### PR DESCRIPTION
(Duplicate of https://github.com/adamlerer/webDiplomacy/pull/121 , which was reverted )

WIP on processing votes from the beta UI.

A wart I don't know how to deal with: When you cancel a game, the backend literally deletes it from the DB (!) and then any future requests about that game return an error. Of course this crashes the UI.

Most of the rest of the functionality for processing votes sorta works here. E.g. if you induce a draw the game will process and the UI will progress to the Finished screen.