### PR TITLE
Fix dislodge drawing

### DIFF
--- a/beta-src/src/utils/map/getUnits.ts
+++ b/beta-src/src/utils/map/getUnits.ts
@@ -81,7 +81,7 @@ export function getUnitsLive(
   // Maps current terrID => previous terrID for units that successfully moved last phase.
   const successfulPrevMoves: { [key: string]: string } = {};
   prevPhaseOrders.forEach((prevOrder) => {
-    if (prevOrder.success && prevOrder.type === "Move") {
+    if (prevOrder.success === "Yes" && prevOrder.type === "Move") {
       successfulPrevMoves[prevOrder.toTerrID.toString()] =
         prevOrder.terrID.toString();
     }
@@ -272,7 +272,7 @@ export function getUnitsHistorical(
   // Maps current terrID => previous terrID for units that successfully moved last phase.
   const successfulPrevMoves: { [key: string]: string } = {};
   prevPhaseOrders.forEach((prevOrder) => {
-    if (prevOrder.success && prevOrder.type === "Move") {
+    if (prevOrder.success === "Yes" && prevOrder.type === "Move") {
       successfulPrevMoves[prevOrder.toTerrID.toString()] =
         prevOrder.terrID.toString();
     }


### PR DESCRIPTION
We accidentally treated this field as truthy when actually it was "No"/"Yes"y. This messed up dislodge drawing sometimes.

Previous phase:
![image](https://user-images.githubusercontent.com/11942395/181132178-3a17c9c2-cb3f-4eda-80bb-5a4960ceaaff.png)

Next phase before bugfix:
![image](https://user-images.githubusercontent.com/11942395/181132304-10ebfd9e-9acf-45ef-a43d-869570673f80.png)

Next phase after bugfix:
![image](https://user-images.githubusercontent.com/11942395/181132183-db1b722c-ff3f-41ca-99bc-fd44914928bb.png)
