### PR TITLE
Possible fix for npm build type error

### DIFF
--- a/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
+++ b/beta-src/src/utils/state/gameApiSlice/extraReducers/fetchGameData/fulfilled.ts
@@ -34,7 +34,7 @@ export default function fetchGameDataFulfilled(state: GameState, action): void {
   }
 
   state.data = action.payload;
-  const currentState = current(state);
+  const currentState = current(state) as GameState;
   const {
     data: { data },
     overview: { phase, user },


### PR DESCRIPTION
TS2571: Object is of type 'unknown' sure to current(state) returning an unknown type, at least in my VS Code environment which does have the npm etc versions specified. Have little Typescript experience so interested in information on why I might need this to run.

The error I get without this is on this line, where unit is type unknown.
if (unit.countryID === user?.member.countryID.toString()) {