### PR TITLE
switch to modern autoload variant that doesn't conflict with composer autoload

### DIFF
--- a/variants/variant.php
+++ b/variants/variant.php
@@ -154,7 +154,7 @@ abstract class WDVariant {
 	public function __call($name, $args) {
 
 		$name = l_vc($name);
-		
+
 		if( isset($this->variantClasses[$name]) )
 			$classname=$this->variantClasses[$name].'Variant_'.$name;
 		else
@@ -388,7 +388,7 @@ abstract class WDVariant {
  * [Name]Variant -> variants/[Name]/variant.php
  * [Name]Variant_[Class] -> variants/[Name]/classes/[Class].php
  */
-function __autoload($classname) {
+function variant_autoloader($classname) {
 
 	if( !( $pos=strpos($classname,'Variant') ) || $pos==0 ) return;
 
@@ -399,5 +399,7 @@ function __autoload($classname) {
 	else
 		require_once(l_r('variants/'.$variantName.'/classes/'.substr($classname, ($pos+8)).'.php'));
 }
+
+spl_autoload_register('variant_autoloader');
 
 ?>


### PR DESCRIPTION
I think the `__autoload` function was interfering with some `composer` autoload functionality, leading to this error.

<img width="569" alt="image" src="https://user-images.githubusercontent.com/5702157/188992579-3307ac1f-91d7-428b-9c38-cd7dedf2a5a1.png">


Switching to this more modern registration function fixes it.

https://www.php.net/manual/en/language.oop5.autoload.php