### PR TITLE
Remove Suspense loading screen which improves other things

### DIFF
--- a/beta-src/src/components/controllers/WDMainController.tsx
+++ b/beta-src/src/components/controllers/WDMainController.tsx
@@ -95,9 +95,6 @@ const WDMainController: React.FC = function ({ children }): React.ReactElement {
     document.title = `${name} - webDiplomacy`;
   }, [name, gameID]);
 
-  if (!consistentPhase) {
-    return <div>Loading...</div>;
-  }
   const showOverlay = noPhase || status.status === "Left";
   if (displayedPhaseKey === null && overview.phase) {
     setDisplayedPhaseKey(overviewKey);

--- a/beta-src/src/components/ui/WDMain.tsx
+++ b/beta-src/src/components/ui/WDMain.tsx
@@ -19,9 +19,7 @@ import {
 import { StandoffInfo } from "../map/components/WDArrowContainer";
 import WDGameFinishedOverlay from "./WDGameFinishedOverlay";
 
-const WDMapController = React.lazy(
-  () => import("../controllers/WDMapController"),
-);
+import WDMapController from "../controllers/WDMapController"
 
 const WDMain: React.FC = function (): React.ReactElement {
   // console.log("WDMain rerendered");
@@ -323,7 +321,6 @@ const WDMain: React.FC = function (): React.ReactElement {
     (viewedPhaseState.viewedPhaseIdx === status.phases.length - 1 ||
       status.phases.length === 0);
   return (
-    <React.Suspense fallback={<div>Loading...</div>}>
       <WDMainController>
         <WDMapController
           units={units}
@@ -341,7 +338,6 @@ const WDMain: React.FC = function (): React.ReactElement {
           viewingGameFinishedPhase={viewingGameFinishedPhase}
         />
       </WDMainController>
-    </React.Suspense>
   );
 };
 

--- a/beta-src/src/components/ui/WDMain.tsx
+++ b/beta-src/src/components/ui/WDMain.tsx
@@ -19,7 +19,7 @@ import {
 import { StandoffInfo } from "../map/components/WDArrowContainer";
 import WDGameFinishedOverlay from "./WDGameFinishedOverlay";
 
-import WDMapController from "../controllers/WDMapController"
+import WDMapController from "../controllers/WDMapController";
 
 const WDMain: React.FC = function (): React.ReactElement {
   // console.log("WDMain rerendered");
@@ -321,23 +321,23 @@ const WDMain: React.FC = function (): React.ReactElement {
     (viewedPhaseState.viewedPhaseIdx === status.phases.length - 1 ||
       status.phases.length === 0);
   return (
-      <WDMainController>
-        <WDMapController
-          units={units}
-          phase={phase}
-          orders={orders}
-          maps={maps}
-          territories={territories}
-          centersByProvince={centersByProvince}
-          standoffs={standoffs}
-          isLivePhase={isLivePhase}
-        />
-        <WDUI
-          orders={orders}
-          units={units}
-          viewingGameFinishedPhase={viewingGameFinishedPhase}
-        />
-      </WDMainController>
+    <WDMainController>
+      <WDMapController
+        units={units}
+        phase={phase}
+        orders={orders}
+        maps={maps}
+        territories={territories}
+        centersByProvince={centersByProvince}
+        standoffs={standoffs}
+        isLivePhase={isLivePhase}
+      />
+      <WDUI
+        orders={orders}
+        units={units}
+        viewingGameFinishedPhase={viewingGameFinishedPhase}
+      />
+    </WDMainController>
   );
 };
 

--- a/beta-src/src/components/ui/WDUI.tsx
+++ b/beta-src/src/components/ui/WDUI.tsx
@@ -26,7 +26,7 @@ import {
   getHistoricalPhaseSeasonYear,
 } from "../../utils/state/getPhaseSeasonYear";
 import WDClassesJIT from "./WDClassesJIT";
-import WDLoading from "../miscellaneous/Loading";
+// import WDLoading from "../miscellaneous/Loading";
 
 interface WDUIProps {
   orders: IOrderDataHistorical[];

--- a/beta-src/src/components/ui/main-screen/BottomMiddle.tsx
+++ b/beta-src/src/components/ui/main-screen/BottomMiddle.tsx
@@ -84,8 +84,7 @@ const BottomMiddle: FunctionComponent<BottomMiddleProps> = function ({
   const [isNewPhase, setIsNewPhase] = useState<boolean>(false);
   const [lastViewedPhase, setLastViewedPhase] =
     useState<number>(viewedPhaseIdx);
-  const [lastPhase, setLastPhase] =
-    useState<string>("");
+  const [lastPhase, setLastPhase] = useState<string>("");
 
   useEffect(() => {
     if (phase === "Loading") return;
@@ -93,9 +92,7 @@ const BottomMiddle: FunctionComponent<BottomMiddleProps> = function ({
     if (lastPhase !== curPhase && viewedPhaseIdx < totalPhases) {
       setIsNewPhase(true);
     }
-    if (
-      viewedPhaseIdx !== lastViewedPhase
-    ) {
+    if (viewedPhaseIdx !== lastViewedPhase) {
       setIsNewPhase(false);
     }
     setLastViewedPhase(viewedPhaseIdx);

--- a/beta-src/src/components/ui/main-screen/BottomMiddle.tsx
+++ b/beta-src/src/components/ui/main-screen/BottomMiddle.tsx
@@ -57,7 +57,7 @@ const NextPhase = function (): ReactElement {
         <button
           type="button"
           onClick={async () => {
-            dispatch(gameApiSliceActions.changeViewedPhaseIdxBy(1));
+            dispatch(gameApiSliceActions.setViewedPhaseToLatest());
           }}
         >
           <BtnArrowIcon
@@ -79,20 +79,28 @@ const BottomMiddle: FunctionComponent<BottomMiddleProps> = function ({
   totalPhases,
 }: BottomMiddleProps): ReactElement {
   const { viewedPhaseIdx } = useAppSelector(gameViewedPhase);
+  const { phase, season, year } = useAppSelector(gameOverview);
   const { width } = useWindowSize();
-  const [isNewPhase, setIsNewPhase] = useState<boolean>(true);
+  const [isNewPhase, setIsNewPhase] = useState<boolean>(false);
   const [lastViewedPhase, setLastViewedPhase] =
     useState<number>(viewedPhaseIdx);
+  const [lastPhase, setLastPhase] =
+    useState<string>("");
 
   useEffect(() => {
+    if (phase === "Loading") return;
+    const curPhase = `${phase}-${season}-${year}`;
+    if (lastPhase !== curPhase && viewedPhaseIdx < totalPhases) {
+      setIsNewPhase(true);
+    }
     if (
-      viewedPhaseIdx !== lastViewedPhase ||
-      viewedPhaseIdx === totalPhases - 1
+      viewedPhaseIdx !== lastViewedPhase
     ) {
       setIsNewPhase(false);
     }
     setLastViewedPhase(viewedPhaseIdx);
-  }, [viewedPhaseIdx]);
+    setLastPhase(curPhase);
+  }, [viewedPhaseIdx, phase, season, year]);
 
   return (
     <WDPositionContainer

--- a/beta-src/src/components/ui/main-screen/buttons/OpenModalButton.tsx
+++ b/beta-src/src/components/ui/main-screen/buttons/OpenModalButton.tsx
@@ -42,12 +42,11 @@ const OpenModalButton: FunctionComponent<BottomRightProps> = function ({
   const { width } = useWindowSize();
   const popoverTrigger = React.useRef<HTMLDivElement>(null);
   const [currentTab, setCurrentTab] = useState(ModalViews.PRESS);
-
   const {
     ref: modalRef,
     isComponentVisible,
     setIsComponentVisible,
-  } = useComponentVisible(true, currentTab !== ModalViews.PRESS || width < 500);
+  } = useComponentVisible(false, width < 1000);
 
   const {
     alternatives,
@@ -108,10 +107,6 @@ const OpenModalButton: FunctionComponent<BottomRightProps> = function ({
   const toggleControlModal = () => {
     setIsComponentVisible(!isComponentVisible);
   };
-
-  useEffect(() => {
-    setIsComponentVisible(true);
-  }, []);
 
   const controlModalTrigger = (
     <RightButton

--- a/beta-src/src/state/game/game-api-slice.ts
+++ b/beta-src/src/state/game/game-api-slice.ts
@@ -302,6 +302,9 @@ const gameApiSlice = createSlice({
       state.viewedPhaseState.viewedPhaseIdx =
         state.viewedPhaseState.latestPhaseViewed;
     },
+    setViewedPhaseToLatest(state) {
+      state.viewedPhaseState.viewedPhaseIdx = state.status.phases.length - 1;
+    },
     setAlert(state, action) {
       setAlert(state.alert, action.payload);
     },


### PR DESCRIPTION
Every time the phase changes, we switch to a "Loading..." screen which accomplishes nothing but resets the internal state of every other component. This is why e.g. the press window pops up every time a phase changes. Got rid of the suspense and fixed some things up to interoperate with it. Phase changes are smoother now.

https://user-images.githubusercontent.com/5702157/189511517-a790c5b6-1333-4314-b504-1d3d71840faa.mov


