### PR TITLE
Fix auto-fill support moves to coasts

### DIFF
--- a/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
@@ -319,9 +319,17 @@ export default function processMapClick(
           maps.provinceIDToUnits[maps.terrIDToProvinceID[order.fromTerrID]][0];
         if (ownUnits.includes(targetUnitID) && fromTerrID !== toTerrID) {
           startNewOrder(state, { unitID: targetUnitID });
+          let coastalToTerrID = toTerrID;
+          if (data.units[targetUnitID].type === "Fleet") {
+            const coastalToTerr = getBestCoastalUnitTerritory(
+              evt,
+              clickProvinceMapData,
+            );
+            coastalToTerrID = maps.territoryToTerrID[coastalToTerr];
+          }
           updateOrder(state, {
             convoyPath,
-            toTerrID,
+            toTerrID: coastalToTerrID,
             type: "Move",
             viaConvoy: convoyPath ? "Yes" : "No",
           });


### PR DESCRIPTION
Auto-filling support to a coast wasn't working before. Now it enters the move to the coast that you click on (even though the support isn't coast-specific).


https://user-images.githubusercontent.com/5702157/192033897-e1c8af82-ba16-46e0-8199-61ef403ace7b.mov

