### PR TITLE
Only support moves to legal coasts

### DIFF
--- a/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
+++ b/beta-src/src/utils/state/gameApiSlice/reducers/processMapClick.ts
@@ -313,20 +313,34 @@ export default function processMapClick(
           toTerrID,
           convoyPath,
         });
-
         // if it's a support-move of my unit, fill it in
         const targetUnitID =
           maps.provinceIDToUnits[maps.terrIDToProvinceID[order.fromTerrID]][0];
+
         if (ownUnits.includes(targetUnitID) && fromTerrID !== toTerrID) {
-          startNewOrder(state, { unitID: targetUnitID });
           let coastalToTerrID = toTerrID;
+          let coastalToTerr = clickRootTerritory;
+
           if (data.units[targetUnitID].type === "Fleet") {
-            const coastalToTerr = getBestCoastalUnitTerritory(
-              evt,
-              clickProvinceMapData,
+            const legalDests = legalOrders.legalMoveDestsByUnitID[targetUnitID];
+            const slotDests = clickProvinceMapData.unitSlots.map(
+              (slot) => slot.territory,
             );
+            const legalDestsInProvince = legalDests.filter((terr) =>
+              slotDests.includes(terr),
+            );
+            if (legalDestsInProvince.length === 1) {
+              [coastalToTerr] = legalDestsInProvince;
+            } else {
+              // find the best one
+              coastalToTerr = getBestCoastalUnitTerritory(
+                evt,
+                clickProvinceMapData,
+              );
+            }
             coastalToTerrID = maps.territoryToTerrID[coastalToTerr];
           }
+          startNewOrder(state, { unitID: targetUnitID });
           updateOrder(state, {
             convoyPath,
             toTerrID: coastalToTerrID,


### PR DESCRIPTION
This fixes a bug where you could support a move to an illegal coast.

The problem before the fix is that you could enter a support to an illegal coast. And while that's fine for the support itself (which is to the root territory), the supported move is illegal and doesn't get saved.



After:



https://user-images.githubusercontent.com/5702157/195146743-c65e5d19-7f87-4d62-b5e4-a7bbcb79965b.mov


https://user-images.githubusercontent.com/5702157/195146748-102625c6-233d-40c4-9d36-0058bd7144c1.mov

